### PR TITLE
Fix Qwen3-235B A22B with new version of vllm

### DIFF
--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
@@ -81,7 +81,7 @@ class CompressedTensorsMoEMethod(FusedMoEMethodBase):
                     "WNA16MoE is not supported with actorder=group/dynamic."
                 )
             logger.info_once("Using CompressedTensorsWNA16MoEMethod")
-            return CompressedTensorsWNA16MoEMethod(quant_config)
+            return CompressedTensorsWNA16MoEMethod(quant_config, layer.moe_config)
         elif quant_config._is_fp4a4_nvfp4(weight_quant, input_quant):
             return CompressedTensorsW4A4MoeMethod(layer.moe_config, layer)
         elif (quant_config._is_fp8_w8a8_sm90(weight_quant, input_quant)


### PR DESCRIPTION


<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

This PR fixes model loading with Qwen3-235B A22B - prior to adding the missing layer.moe_config argument, it would crash with error specifying that an argument is required for this to work.

Prior to updating to the latest version (worked on initial release of v0.9.2) - this worked.

```
VLLM_USE_TRITON_FLASH_ATTN=1 vllm serve /data/ModelDownloader/Qwen3-235B-A22B-Instruct-2507-INT4-W4A16  --tensor-parallel-size 8 --port 9100 --enable-expert-parallel  --max-model-len 131072  --enable-prefix-caching --disable-log-requests --kv_cache_dtype auto
```

However after updating to the latest version, it failed with an error indicating that it was missing an moe type.



## Test Plan

It is quite a trivially simple change... I just added the missing argument in... not sure what there is to test.

## Test Result

Model loads now - runs at 14.5 tok/s vs 7 tok/s with v0.9.2.

At large contexts, it still performs better, ~7tok/s vs 5 tok/s.

This is of course not due to anything I changed - just an observed improvement now that it's working!

```
(APIServer pid=872771) INFO 09-14 02:30:25 [loggers.py:123] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 15.1 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.1%, Prefix cache hit rate: 31.7%
(APIServer pid=872771) INFO 09-14 02:30:35 [loggers.py:123] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 14.8 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.1%, Prefix cache hit rate: 31.7%
```

## (Optional) Documentation Update

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
