### PR TITLE
Glm 4.5 perf improvements

### DIFF
--- a/WORKING_MODELS.md
+++ b/WORKING_MODELS.md
@@ -1,0 +1,10 @@
+Below is a list of models that have been tested as working with vllm-gfx906.
+
+Unless otherwise specified, the benchmark results are on 8 x MI50 32GB.
+
+|  Model |  Quant Format | Quant Bits |  Prompt Processing (tok/s) | Token Generation (tok/s) | Link |
+|---|---|---|---|---|---|
+|GLM-4.5|  AWQ | 4  |  ? |  9.2 | https://huggingface.co/cpatonn/GLM-4.5-Air-AWQ-4bit  |
+
+
+TODO: create standardized benchmark for PP+TG@1k context, 8k context, 16k context, expand table.

--- a/vllm/model_executor/layers/fused_moe/configs/E=20,N=1536,device_name=AMD_Instinct_MI50_MI60,dtype=int4_w4a16.json
+++ b/vllm/model_executor/layers/fused_moe/configs/E=20,N=1536,device_name=AMD_Instinct_MI50_MI60,dtype=int4_w4a16.json
@@ -1,0 +1,10 @@
+{
+    "1024": {"BLOCK_SIZE_M": 64, "BLOCK_SIZE_N": 64, "BLOCK_SIZE_K": 32,
+             "GROUP_SIZE_M": 8, "num_warps": 4, "num_stages": 2},
+    "2048": {"BLOCK_SIZE_M": 64, "BLOCK_SIZE_N": 64, "BLOCK_SIZE_K": 32,
+             "GROUP_SIZE_M": 8, "num_warps": 4, "num_stages": 2},
+    "4096": {"BLOCK_SIZE_M": 64, "BLOCK_SIZE_N": 64, "BLOCK_SIZE_K": 32,
+             "GROUP_SIZE_M": 8, "num_warps": 4, "num_stages": 2},
+    "8192": {"BLOCK_SIZE_M": 64, "BLOCK_SIZE_N": 64, "BLOCK_SIZE_K": 32,
+             "GROUP_SIZE_M": 8, "num_warps": 4, "num_stages": 2}
+}

--- a/vllm/model_executor/layers/fused_moe/configs/E=20,N=1536,device_name=AMD_Instinct_MI50_MI60,dtype=int4_w4a16.json
+++ b/vllm/model_executor/layers/fused_moe/configs/E=20,N=1536,device_name=AMD_Instinct_MI50_MI60,dtype=int4_w4a16.json
@@ -1,10 +1,34 @@
 {
-    "1024": {"BLOCK_SIZE_M": 64, "BLOCK_SIZE_N": 64, "BLOCK_SIZE_K": 32,
-             "GROUP_SIZE_M": 8, "num_warps": 4, "num_stages": 2},
-    "2048": {"BLOCK_SIZE_M": 64, "BLOCK_SIZE_N": 64, "BLOCK_SIZE_K": 32,
-             "GROUP_SIZE_M": 8, "num_warps": 4, "num_stages": 2},
-    "4096": {"BLOCK_SIZE_M": 64, "BLOCK_SIZE_N": 64, "BLOCK_SIZE_K": 32,
-             "GROUP_SIZE_M": 8, "num_warps": 4, "num_stages": 2},
-    "8192": {"BLOCK_SIZE_M": 64, "BLOCK_SIZE_N": 64, "BLOCK_SIZE_K": 32,
-             "GROUP_SIZE_M": 8, "num_warps": 4, "num_stages": 2}
+    "1024": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 1
+    },
+    "2048": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 1
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 1
+    },
+    "8192": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 1
+    }
 }

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -699,7 +699,9 @@ def get_moe_configs(
     # First look up if an optimized configuration is available in the configs
     # directory
     block_shape = [block_n, block_k] if block_n and block_k else None
-    json_file_name = get_config_file_name(E, N, dtype, block_shape)
+    json_file_name = get_config_file_name(E, N, dtype, block_shape).replace("/","_") # We replace / so that AMD MI50/MI60 -> AMD MI50_MI60, does not need subdir
+
+    
 
     config_file_paths = []
 

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
@@ -81,7 +81,7 @@ class CompressedTensorsMoEMethod(FusedMoEMethodBase):
                     "WNA16MoE is not supported with actorder=group/dynamic."
                 )
             logger.info_once("Using CompressedTensorsWNA16MoEMethod")
-            return CompressedTensorsWNA16MoEMethod(quant_config)
+            return CompressedTensorsWNA16MoEMethod(quant_config, layer.moe_config)
         elif quant_config._is_fp4a4_nvfp4(weight_quant, input_quant):
             return CompressedTensorsW4A4MoeMethod(layer.moe_config, layer)
         elif (quant_config._is_fp8_w8a8_sm90(weight_quant, input_quant)


### PR DESCRIPTION
I went through and tweaked the fused_moe config for GLM4.5. 

I'd be happy to do this with other models as well - could be automated. The VLLM existing config generation tool doesn't support wNa16, so we could make our own or adapt theirs. I did have issues getting it to run at all though, so it might be easier to just build a script to try permutations of BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K, GROUP_SIZE_M, num_warps, and num_stages.

Also went and changed the code to replace device name ...MI50/MI60... -> MI50_MI60 (would treat the / as directory when attempting to load the fused moe config).

Observed a speedup from 7.8 tok/s to 9.2 tok/s. Not a lot but it's something.

For reproducibility here's the command I used.

```
VLLM_USE_TRITON_FLASH_ATTN=1 vllm serve /data/ModelDownloader/GLM-4.5-AWQ-4bit/   --tensor-parallel-size 8   --port 9100   --enable-expert-parallel   --max-model-len 65535   --enable-prefix-caching   --kv-cache-dtype auto   --gpu-memory-utilization 0.95   --max-num-batched-tokens 8192
```

Also, if you have any ideas on where to start poking around to make MoEs faster, let me know - happy to poke around and see what I can come up with.

