### PR TITLE
gfx906/v0.10.1 MXFP4, MoE Tuning Fix and add GPT-OSS harmony flag for performance check

### DIFF
--- a/benchmarks/kernels/benchmark_moe.py
+++ b/benchmarks/kernels/benchmark_moe.py
@@ -392,13 +392,24 @@ def merge_unique_dicts(list1, list2):
 @ray.remote(num_gpus=1)
 class BenchmarkWorker:
     def __init__(self, seed: int) -> None:
-        torch.set_default_device("cuda")
         current_platform.seed_everything(seed)
         self.seed = seed
-        # Get the device ID to allocate tensors and kernels
-        # on the respective GPU. This is required for Ray to work
-        # correctly with multi-GPU tuning on the ROCm platform.
-        self.device_id = int(ray.get_gpu_ids()[0])
+        # Ray returns the physical GPU ordinal. When ROCR_VISIBLE_DEVICES is
+        # set, each worker only exposes a single logical GPU (cuda:0).
+        if current_platform.is_rocm():
+            rocr_visible = os.environ.get("ROCR_VISIBLE_DEVICES")
+            if rocr_visible:
+                os.environ.setdefault("HIP_VISIBLE_DEVICES", rocr_visible)
+                os.environ.setdefault("CUDA_VISIBLE_DEVICES", rocr_visible)
+        else:
+            cuda_visible = os.environ.get("CUDA_VISIBLE_DEVICES")
+            if cuda_visible:
+                os.environ.setdefault("HIP_VISIBLE_DEVICES", cuda_visible)
+        # Ray assigns one GPU per worker, which is exposed as cuda:0 inside the
+        # worker process once the visible devices are set.
+        self.device_id = 0
+        torch.cuda.set_device(self.device_id)
+        torch.set_default_device("cuda:0")
 
     def benchmark(
         self,
@@ -477,13 +488,14 @@ class BenchmarkWorker:
                 topk,
             )
 
-        need_device_guard = False
         if current_platform.is_rocm():
-            visible_device = os.environ.get("ROCR_VISIBLE_DEVICES", None)
-            if visible_device != f"{self.device_id}":
-                need_device_guard = True
-
-        with torch.cuda.device(self.device_id) if need_device_guard else nullcontext():
+            context = torch.cuda.device(self.device_id)
+        else:
+            visible_device = os.environ.get("CUDA_VISIBLE_DEVICES", None)
+            need_device_guard = (visible_device is not None and
+                                 visible_device != f"{self.device_id}")
+            context = torch.cuda.device(self.device_id) if need_device_guard else nullcontext()
+        with context:
             for config in tqdm(search_space):
                 try:
                     kernel_time = benchmark_config(

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -3,6 +3,7 @@
 
 import asyncio
 import json
+import os
 import time
 from collections.abc import AsyncGenerator, AsyncIterator
 from collections.abc import Sequence as GenericSequence
@@ -134,7 +135,10 @@ class OpenAIServingChat(OpenAIServing):
             logger.info("Using default chat sampling params from %s: %s",
                         source, self.default_sampling_params)
 
-        self.use_harmony = model_config.hf_config.model_type == "gpt_oss"
+        disable_harmony = os.getenv("VLLM_DISABLE_GPTOSS_HARMONY", "0") == "1"
+        self.use_harmony = (
+            model_config.hf_config.model_type == "gpt_oss"
+            and not disable_harmony)
         if self.use_harmony:
             if "stop_token_ids" not in self.default_sampling_params:
                 self.default_sampling_params["stop_token_ids"] = []

--- a/vllm/entrypoints/openai/serving_responses.py
+++ b/vllm/entrypoints/openai/serving_responses.py
@@ -3,6 +3,7 @@
 
 import asyncio
 import json
+import os
 import time
 from collections.abc import AsyncGenerator, AsyncIterator
 from contextlib import AsyncExitStack
@@ -132,7 +133,10 @@ class OpenAIServingResponses(OpenAIServing):
                 "cause a memory leak since we never remove responses from "
                 "the store.")
 
-        self.use_harmony = model_config.hf_config.model_type == "gpt_oss"
+        disable_harmony = os.getenv("VLLM_DISABLE_GPTOSS_HARMONY", "0") == "1"
+        self.use_harmony = (
+            model_config.hf_config.model_type == "gpt_oss"
+            and not disable_harmony)
         if self.use_harmony:
             logger.warning("For gpt-oss, we ignore --enable-auto-tool-choice "
                            "and always enable tool use.")

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -8,7 +8,8 @@ from torch.nn.parameter import Parameter
 from vllm import envs
 from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe import (FusedMoE, FusedMoEConfig,
-                                                  FusedMoEMethodBase)
+                                                  FusedMoEMethodBase,
+                                                  fused_experts)
 from vllm.model_executor.layers.fused_moe.gpt_oss_triton_kernels_moe import (
     triton_kernel_moe_forward)
 from vllm.model_executor.layers.linear import (LinearBase,
@@ -19,7 +20,7 @@ from vllm.model_executor.layers.quantization.base_config import (
 from vllm.model_executor.layers.quantization.utils.marlin_utils_fp4 import (
     prepare_moe_fp4_layer_for_marlin)
 from vllm.model_executor.layers.quantization.utils.mxfp4_utils import (
-    _can_support_mxfp4, _swizzle_mxfp4)
+    _can_support_mxfp4, _swizzle_mxfp4, dequant_mxfp4)
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     is_layer_skipped)
 from vllm.model_executor.utils import set_weight_attrs
@@ -81,7 +82,10 @@ class Mxfp4Config(QuantizationConfig):
 
     @classmethod
     def get_supported_act_dtypes(cls) -> list[torch.dtype]:
-        return [torch.bfloat16]
+        dtypes = [torch.bfloat16]
+        if torch.float16 in current_platform.supported_dtypes:
+            dtypes.append(torch.float16)
+        return dtypes
 
     @classmethod
     def get_config_filenames(cls) -> list[str]:
@@ -113,6 +117,11 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         self.topk_indices_dtype = None
         self.moe = moe
         self.use_marlin = self._should_use_marlin()
+        self.use_emulated_mxfp4 = False
+        self.w13_precision_config = None
+        self.w2_precision_config = None
+        self.w13_weight_triton_tensor = None
+        self.w2_weight_triton_tensor = None
 
         if current_platform.is_device_capability(100) and not has_flashinfer():
             logger.warning_once(
@@ -384,7 +393,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             layer.w2_bias = Parameter(torch.stack(gemm2_bias_shuffled).reshape(
                 self.num_experts, -1),
                                       requires_grad=False)
-        else:
+        elif current_platform.supports_mx() and has_triton_kernels():
             from triton_kernels.matmul_ogs import FlexCtx, PrecisionConfig
 
             w13_bias = layer.w13_bias.to(torch.float32)
@@ -419,6 +428,23 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             layer.w13_weight = None
             layer.w2_weight = None
             torch.cuda.empty_cache()
+        else:
+            # Fall back to emulation when MX kernels are unavailable.
+            self.use_emulated_mxfp4 = True
+            layer.w13_bias = Parameter(layer.w13_bias.to(torch.float16),
+                                       requires_grad=False)
+            layer.w2_bias = Parameter(layer.w2_bias.to(torch.float16),
+                                      requires_grad=False)
+            w_device = layer.w13_weight.device
+            layer.w13_weight_scale = Parameter(
+                layer.w13_weight_scale.to(device=w_device, dtype=torch.uint8),
+                requires_grad=False)
+            layer.w2_weight_scale = Parameter(
+                layer.w2_weight_scale.to(device=w_device, dtype=torch.uint8),
+                requires_grad=False)
+            logger.warning_once(
+                "MXFP4 kernels are unavailable on this platform. Falling back"
+                " to simulated MXFP4 execution using float16 activations.")
 
     def _get_tile_tokens_dim(self, x: torch.Tensor, top_k: int):
         # Number of tokens in the input tensor.
@@ -501,6 +527,48 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 global_num_experts=global_num_experts,
                 activation=activation,
                 expert_map=expert_map)
+
+        if self.use_emulated_mxfp4:
+            x = x.to(torch.float16)
+            if router_logits.dtype != x.dtype:
+                router_logits = router_logits.to(x.dtype)
+            topk_weights, topk_ids = FusedMoE.select_experts(
+                hidden_states=x,
+                router_logits=router_logits,
+                use_grouped_topk=use_grouped_topk,
+                top_k=top_k,
+                renormalize=renormalize,
+                topk_group=topk_group,
+                num_expert_group=num_expert_group,
+                custom_routing_function=custom_routing_function,
+                scoring_func=scoring_func,
+                e_score_correction_bias=e_score_correction_bias,
+                indices_type=self.topk_indices_dtype,
+                enable_eplb=enable_eplb,
+                expert_map=expert_map,
+                expert_load_view=expert_load_view,
+                logical_to_physical_map=logical_to_physical_map,
+                logical_replica_count=logical_replica_count)
+
+            w1 = dequant_mxfp4(layer.w13_weight, layer.w13_weight_scale,
+                                x.dtype)
+            w2 = dequant_mxfp4(layer.w2_weight, layer.w2_weight_scale,
+                                x.dtype)
+
+            return fused_experts(
+                hidden_states=x,
+                w1=w1,
+                w2=w2,
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+                activation=activation,
+                apply_router_weight_on_input=apply_router_weight_on_input,
+                global_num_experts=global_num_experts,
+                expert_map=expert_map,
+                w1_scale=None,
+                w2_scale=None,
+                w1_bias=layer.w13_bias,
+                w2_bias=layer.w2_bias)
 
         assert _can_support_mxfp4(
             use_grouped_topk, topk_group, num_expert_group, expert_map,

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from copy import deepcopy
+import os
 from typing import TYPE_CHECKING
 
 import vllm.envs as envs
@@ -252,8 +253,12 @@ class GptOssForCausalLMConfig(VerifyAndUpdateConfig):
     @staticmethod
     def verify_and_update_config(vllm_config: "VllmConfig") -> None:
         decoding_config = vllm_config.decoding_config
+        disable_harmony = os.getenv("VLLM_DISABLE_GPTOSS_HARMONY", "0") == "1"
         if decoding_config.reasoning_backend == "":
-            decoding_config.reasoning_backend = "GptOss"
+            if not disable_harmony:
+                decoding_config.reasoning_backend = "GptOss"
+        elif disable_harmony and decoding_config.reasoning_backend == "GptOss":
+            decoding_config.reasoning_backend = ""
 
         # Increase the max capture size from 512 to 1024 for performance.
         # NOTE(woosuk): This will increase the number of CUDA graphs

--- a/vllm/model_executor/models/gpt_oss.py
+++ b/vllm/model_executor/models/gpt_oss.py
@@ -26,6 +26,7 @@ from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.model_executor.sampling_metadata import SamplingMetadata
 from vllm.sequence import IntermediateTensors
 from vllm.utils import cdiv
+from vllm.platforms import current_platform
 
 from .utils import extract_layer_index, maybe_prefix
 
@@ -145,9 +146,12 @@ class MLPBlock(torch.nn.Module):
         self.experts_per_token = config.num_experts_per_tok
         self.world_size = dist.get_world_size() if dist.is_initialized() else 1
         self.norm = RMSNorm(config.hidden_size, eps=1e-5)
+        router_dtype = torch.bfloat16
+        if router_dtype not in current_platform.supported_dtypes:
+            router_dtype = torch.float16
         self.router = torch.nn.Linear(config.hidden_size,
                                       config.num_local_experts,
-                                      dtype=torch.bfloat16)
+                                      dtype=router_dtype)
         assert config.intermediate_size % self.world_size == 0
         self.experts = FusedMoE(num_experts=config.num_local_experts,
                                 top_k=config.num_experts_per_tok,
@@ -163,7 +167,12 @@ class MLPBlock(torch.nn.Module):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         t = self.norm(x)
-        g = self.router(t)
+        router_input = t
+        if router_input.dtype != self.router.weight.dtype:
+            router_input = router_input.to(self.router.weight.dtype)
+        g = self.router(router_input)
+        if g.dtype != t.dtype:
+            g = g.to(t.dtype)
         t = self.experts(hidden_states=t, router_logits=g)
         return x + t
 


### PR DESCRIPTION
## Summary
- Fix MXFP4 fallback on gfx906: keep scales in `uint8` on the right device, cast router logits, and dequant via `fused_experts`, so MXFP4 checkpoints run in FP16 emulation without Quark errors (requires `pip install amd-quark` and `apt-get install -y libxml2` in the current `nlzy/vllm-gfx906` Docker image).
- Make the GPT-OSS MoE router pick a dtype supported on ROCm and cast inputs/outputs to avoid BF16/Half mismatches.
- Add `VLLM_DISABLE_GPTOSS_HARMONY` so GPT-OSS reasoning wrappers can be toggled; the config no longer forces the parser when the flag is set, and both OpenAI front-ends skip Harmony in that case.
- Update `benchmark_moe.py` to honor `ROCR_VISIBLE_DEVICES`/`CUDA_VISIBLE_DEVICES`, pin Ray workers to `cuda:0`, and guard kernel launches with the correct device context.

## Testing
- `benchmarks/kernels/benchmark_moe.py`  
  - Tuned `Qwen3-30B-A3B-Thinking-2507-GPTQ-Int8` with `--enable-expert-parallel --tensor-parallel-size 4`; generated `E=32,N=768,device_name=Radeon_Instinct_MI50_32GB,dtype=int8_w8a16.json`.
- vLLM serve on MI50 (gfx906)  
  - MXFP4 checkpoints load and infer in FP16 emulation mode (after installing `amd-quark` and `libxml2`).  
  - `VLLM_DISABLE_GPTOSS_HARMONY=0/1` flips GPT-OSS responses between reasoning-wrapped and plain text (this adjustment is for some benchmarks script).
- Performance: at ~5120-token prompts, tuning improves prefill throughput from 1963 tok/s → 2326 tok/s and decode throughput from 39 tok/s → 47 tok/s (~20% uplift).
