### PR TITLE
add support amd mi50 rocm.txt

### DIFF
--- a/requirements/rocm.txt
+++ b/requirements/rocm.txt
@@ -8,7 +8,7 @@ numba == 0.61.2; python_version > '3.9'
 boto3
 botocore
 datasets
-ray[cgraph]>=2.48.0 # Ray Compiled Graph, required for pipeline parallelism in V1.
+ray[cgraph]>=2.50.0 # Ray Compiled Graph, required for pipeline parallelism in V1. work new support mi50
 peft
 pytest-asyncio
 tensorizer==2.10.1


### PR DESCRIPTION
ray 2.50.0

HIP_VISIBLE_DEVICES_ENV_VAR = "HIP_VISIBLE_DEVICES" NOSET_HIP_VISIBLE_DEVICES_ENV_VAR = "RAY_EXPERIMENTAL_NOSET_HIP_VISIBLE_DEVICES"

amd_product_dict = {
    "0x66a1": "AMD-Instinct-MI50",
    "0x738c": "AMD-Instinct-MI100",
    "0x7408": "AMD-Instinct-MI250X",
    "0x740c": "AMD-Instinct-MI250X-MI250",
    "0x740f": "AMD-Instinct-MI210",
    "0x74a0": "AMD-Instinct-MI300A",
    "0x74a1": "AMD-Instinct-MI300X-OAM",
    "0x74a2": "AMD-Instinct-MI308X-OAM",
    "0x74a9": "AMD-Instinct-MI300X-HF",
    "0x74a5": "AMD-Instinct-MI325X-OAM",
    "0x75a0": "AMD-Instinct-MI350X-OAM",
    "0x75a3": "AMD-Instinct-MI355X-OAM",
    "0x6798": "AMD-Radeon-R9-200-HD-7900",
    "0x6799": "AMD-Radeon-HD-7900",
    "0x679A": "AMD-Radeon-HD-7900",
    "0x679B": "AMD-Radeon-HD-7900",
}