### PR TITLE
[ROCm] Add Deepseek MLA support (experimental) on GFX906

### DIFF
--- a/.buildkite/scripts/generate-nightly-index.py
+++ b/.buildkite/scripts/generate-nightly-index.py
@@ -7,12 +7,13 @@
 
 import argparse
 import json
-import re
 import sys
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
 from urllib.parse import quote
+
+import regex as re
 
 if not sys.version_info >= (3, 12):
     raise RuntimeError("This script requires Python 3.12 or higher.")

--- a/csrc/cache.h
+++ b/csrc/cache.h
@@ -73,3 +73,16 @@ void cp_gather_indexer_k_quant_cache(
     torch::Tensor& dst_scale,  // [num_tokens, head_dim / quant_block_size * 4]
     const torch::Tensor& block_table,   // [batch_size, num_blocks]
     const torch::Tensor& cu_seq_lens);  // [batch_size + 1]
+
+// Indexer K FP16 cache function
+void indexer_k_cache_fp16(
+    torch::Tensor& k,               // [num_tokens, head_dim]
+    torch::Tensor& kv_cache,        // [num_blocks, block_size, cache_stride]
+    torch::Tensor& slot_mapping);    // [num_tokens]
+
+// Extract function to gather K FP16 cache
+void cp_gather_indexer_k_cache_fp16(
+    const torch::Tensor& kv_cache,       // [num_blocks, block_size, cache_stride]
+    torch::Tensor& dst_k,                // [num_tokens, head_dim]
+    const torch::Tensor& block_table,    // [batch_size, num_blocks]
+    const torch::Tensor& cu_seq_lens);     // [batch_size + 1]

--- a/csrc/cache_kernels.cu
+++ b/csrc/cache_kernels.cu
@@ -23,6 +23,8 @@
 typedef __hip_bfloat16 __nv_bfloat16;
 #endif
 
+#include <type_traits> // for std::remove_cv_t
+
 void swap_blocks(torch::Tensor& src, torch::Tensor& dst,
                  const torch::Tensor& block_mapping) {
   torch::Device src_device = src.device();
@@ -516,7 +518,7 @@ __global__ void indexer_k_quant_and_cache_kernel(
     const int cache_stride,  // stride for each token in kv_cache
     const bool use_ue8m0     // use ue8m0 scale format
 ) {
-  constexpr int VEC_SIZE = 4;
+  constexpr int VEC_SIZE = 4; 
   const int64_t token_idx = blockIdx.x;
   const int64_t head_dim_idx = (blockIdx.y * blockDim.y * blockDim.x +
                                 threadIdx.y * blockDim.x + threadIdx.x) *
@@ -524,10 +526,10 @@ __global__ void indexer_k_quant_and_cache_kernel(
   const int64_t slot_idx = slot_mapping[token_idx];
   const int64_t block_idx = slot_idx / cache_block_size;
   const int64_t block_offset = slot_idx % cache_block_size;
-
+  
   // NOTE: slot_idx can be -1 if the token is padded
   if (slot_idx < 0 || (head_dim_idx >= head_dim)) {
-    return;
+      return;
   }
 
   float2 k_val = (reinterpret_cast<const float2*>(
@@ -535,11 +537,11 @@ __global__ void indexer_k_quant_and_cache_kernel(
   scalar_t* k_val_ptr = reinterpret_cast<scalar_t*>(&k_val);
   float amax = 0.0f;
   for (int i = 0; i < VEC_SIZE; i++) {
-    amax = fmaxf(amax, fabsf(float(k_val_ptr[i])));
+      amax = fmaxf(amax, fabsf(float(k_val_ptr[i])));
   }
-#ifndef USE_ROCM
-  __syncwarp();
-#endif
+  #ifndef USE_ROCM
+    __syncwarp();
+  #endif
 
   // Reduced amax
   for (int mask = 16; mask > 0; mask /= 2) {
@@ -558,43 +560,43 @@ __global__ void indexer_k_quant_and_cache_kernel(
   float scale = fmaxf(amax, 1e-4) / 448.0f;
 #endif
   if (use_ue8m0) {
-    scale = exp2f(ceilf(log2f(scale)));
+      scale = exp2f(ceilf(log2f(scale)));
   }
 
   const int64_t dst_offset = block_idx * cache_block_size * cache_stride +
                              block_offset * head_dim + head_dim_idx;
   for (int i = 0; i < VEC_SIZE; i++) {
-    kv_cache[dst_offset + i] =
-        fp8::scaled_convert<cache_t, scalar_t, kv_dt>(k_val_ptr[i], scale);
+      kv_cache[dst_offset + i] =
+          fp8::scaled_convert<cache_t, scalar_t, kv_dt>(k_val_ptr[i], scale);
   }
   if (threadIdx.x == 0) {
-    const int64_t dst_scale_idx =
-        block_idx * cache_block_size * cache_stride +
-        cache_block_size * head_dim +
-        (block_offset * head_dim + head_dim_idx) * 4 / quant_block_size;
-    reinterpret_cast<float*>(kv_cache)[dst_scale_idx / 4] = scale;
+      const int64_t dst_scale_idx =
+          block_idx * cache_block_size * cache_stride +
+          cache_block_size * head_dim +
+          (block_offset * head_dim + head_dim_idx) * 4 / quant_block_size;
+      reinterpret_cast<float*>(kv_cache)[dst_scale_idx / 4] = scale;
   }
 }
 
-template <int BLOCK_Y_SIZE>
-__global__ void cp_gather_indexer_k_quant_cache_kernel(
-    const char* __restrict__ kv_cache,  // [num_blocks, block_size,
-                                        // cache_stride]
-    char* __restrict__ dst_k,           // [num_tokens, head_dim]
+  template <int BLOCK_Y_SIZE>
+  __global__ void cp_gather_indexer_k_quant_cache_kernel(
+      const char* __restrict__ kv_cache,  // [num_blocks, block_size,
+                                          // cache_stride]
+      char* __restrict__ dst_k,           // [num_tokens, head_dim]
     char* __restrict__ dst_scale,  // [num_tokens, head_dim / quant_block_size *
                                    // 4]
-    const int* __restrict__ block_table,  // [batch_size, num_blocks]
-    const int* __restrict__ cu_seq_lens,  // [batch_size + 1]
-    const int batch_size,                 // batch size
-    const int64_t token_stride,           // stride for each token in dst_k
-    const int64_t head_dim,               // dimension of each head
-    const int64_t block_stride,           // stride for each block in kv_cache
-    const int64_t cache_token_stride,     // stride for each token in kv_cache
-    const int64_t cache_block_size,  // num_tokens for each block in kv_cache
-    const int num_blocks,            // number of blocks
-    const int num_tokens,            // number of tokens
-    const int quant_block_size       // quantization block size
-) {
+      const int* __restrict__ block_table,  // [batch_size, num_blocks]
+      const int* __restrict__ cu_seq_lens,  // [batch_size + 1]
+      const int batch_size,                 // batch size
+      const int64_t token_stride,           // stride for each token in dst_k
+      const int64_t head_dim,               // dimension of each head
+      const int64_t block_stride,           // stride for each block in kv_cache
+      const int64_t cache_token_stride,     // stride for each token in kv_cache
+      const int64_t cache_block_size,  // num_tokens for each block in kv_cache
+      const int num_blocks,            // number of blocks
+      const int num_tokens,            // number of tokens
+      const int quant_block_size       // quantization block size
+  ) {
   constexpr int VEC_SIZE = sizeof(float4) / sizeof(char);
   const int token_idx = blockIdx.x * blockDim.y + threadIdx.y;
   const int head_idx = (blockIdx.y * blockDim.x + threadIdx.x) * VEC_SIZE;
@@ -602,22 +604,22 @@ __global__ void cp_gather_indexer_k_quant_cache_kernel(
   __shared__ int batch_idx[BLOCK_Y_SIZE];
   for (int iter = 0; iter < cuda_utils::ceil_div(batch_size, int(blockDim.x));
        iter++) {
-    int tid = iter * blockDim.x + threadIdx.x;
-    if (tid < batch_size) {
-      const int seq_start = cu_seq_lens[tid];
-      const int seq_end = cu_seq_lens[tid + 1];
-      if (token_idx >= seq_start && token_idx < seq_end) {
-        batch_idx[threadIdx.y] = tid;
+      int tid = iter * blockDim.x + threadIdx.x;
+      if (tid < batch_size) {
+          const int seq_start = cu_seq_lens[tid];
+          const int seq_end = cu_seq_lens[tid + 1];
+          if (token_idx >= seq_start && token_idx < seq_end) {
+              batch_idx[threadIdx.y] = tid;
+          }
       }
-    }
   }
 
-#ifndef USE_ROCM
+  #ifndef USE_ROCM
   __syncwarp();
-#endif
+  #endif
 
   if (head_idx >= head_dim || token_idx >= num_tokens) {
-    return;
+      return;
   }
   const int inbatch_seq_idx = token_idx - cu_seq_lens[batch_idx[threadIdx.y]];
   const int block_idx = block_table[batch_idx[threadIdx.y] * num_blocks +
@@ -638,6 +640,153 @@ __global__ void cp_gather_indexer_k_quant_cache_kernel(
     reinterpret_cast<float*>(dst_scale)[dst_inblock_offset / quant_block_size] =
         reinterpret_cast<const float*>(kv_cache)[src_scale_offset / 4];
   }
+}
+
+// -------------------------------------------------------------------------
+// LOCAL VECTOR HELPERS
+// -------------------------------------------------------------------------
+
+template<typename T, int N>
+struct BuiltinVec;
+
+template<> struct BuiltinVec<float, 4> { using Type = float4; };
+template<> struct BuiltinVec<uint16_t, 4> { using Type = float2; };
+template<> struct BuiltinVec<at::Half, 4> { using Type = float2; };
+
+// Helper to cast pointers for vectorized loads.
+// FIX: We use std::remove_cv_t to handle 'const uint16_t' correctly.
+template<typename T, int N>
+__device__ __forceinline__ typename BuiltinVec<std::remove_cv_t<T>, N>::Type* vec_ptr(T* ptr) {
+    using NonConstT = std::remove_cv_t<T>;
+    return reinterpret_cast<typename BuiltinVec<NonConstT, N>::Type*>(const_cast<NonConstT*>(ptr));
+}
+
+// -------------------------------------------------------------------------
+// Kernel 1: Indexer and Cache (Write K to Cache)
+// -------------------------------------------------------------------------
+template <typename scalar_t>
+__global__ void indexer_k_cache_fp16_kernel(
+    const scalar_t* __restrict__ k,          
+    uint16_t* __restrict__ kv_cache,         
+    const int64_t* __restrict__ slot_mapping,
+    const int head_dim,
+    const int cache_block_size,
+    const int cache_stride) {
+    
+    constexpr int VEC_SIZE = 4;
+    using CacheVecType = typename BuiltinVec<uint16_t, VEC_SIZE>::Type;
+
+    const int64_t token_idx = blockIdx.x;
+    const int64_t head_dim_idx = (blockIdx.y * blockDim.y * blockDim.x +
+                                threadIdx.y * blockDim.x + threadIdx.x) * VEC_SIZE;
+
+    if (head_dim_idx >= head_dim) return;
+
+    const int64_t slot_idx = slot_mapping[token_idx];
+    if (slot_idx < 0) return;
+
+    const int64_t block_idx = slot_idx / cache_block_size;
+    const int64_t block_offset = slot_idx % cache_block_size;
+
+    // 1. Vectorized Load
+    using InputVecType = typename BuiltinVec<scalar_t, VEC_SIZE>::Type;
+    InputVecType k_val_vec = *vec_ptr<const scalar_t, VEC_SIZE>(&k[token_idx * head_dim + head_dim_idx]);
+    const scalar_t* k_val_ptr = reinterpret_cast<const scalar_t*>(&k_val_vec);
+
+    // 2. Prepare Destination Offset
+    const int64_t dst_offset = block_idx * cache_block_size * cache_stride +
+                               block_offset * head_dim + head_dim_idx;
+
+    // 3. Convert and Store
+    if constexpr (std::is_same<scalar_t, at::Half>::value) {
+        // Direct vector store
+        *vec_ptr<uint16_t, VEC_SIZE>(&kv_cache[dst_offset]) = 
+            *reinterpret_cast<CacheVecType*>(&k_val_vec);
+    } else {
+        // Float -> Half conversion
+        union {
+            CacheVecType vec;
+            uint16_t arr[VEC_SIZE];
+        } output_buffer;
+
+        #pragma unroll
+        for (int i = 0; i < VEC_SIZE; i++) {
+            // FIX: Store result in temporary var before casting to avoid r-value address error
+            __half temp_half = __float2half(k_val_ptr[i]);
+            output_buffer.arr[i] = *reinterpret_cast<uint16_t*>(&temp_half);
+        }
+        
+        *vec_ptr<uint16_t, VEC_SIZE>(&kv_cache[dst_offset]) = output_buffer.vec;
+    }
+}
+
+// -------------------------------------------------------------------------
+// Kernel 2: Gather (Read K from Cache)
+// -------------------------------------------------------------------------
+template <typename scalar_t, int BLOCK_Y_SIZE>
+__global__ void cp_gather_indexer_k_cache_fp16_kernel(
+    const uint16_t* __restrict__ kv_cache,   
+    scalar_t* __restrict__ dst_k,            
+    const int* __restrict__ block_table,     
+    const int* __restrict__ cu_seq_lens,     
+    const int batch_size,
+    const int64_t token_stride,
+    const int64_t head_dim,
+    const int64_t block_stride,
+    const int64_t cache_block_size,
+    const int num_blocks,
+    const int num_tokens) {
+    
+    constexpr int VEC_SIZE = 4;
+    using DstVecType = typename BuiltinVec<scalar_t, VEC_SIZE>::Type;
+    using CacheVecType = typename BuiltinVec<uint16_t, VEC_SIZE>::Type;
+
+    const int token_idx = blockIdx.x * blockDim.y + threadIdx.y;
+    const int head_idx = (blockIdx.y * blockDim.x + threadIdx.x) * VEC_SIZE;
+
+    __shared__ int batch_idx[BLOCK_Y_SIZE];
+    for (int iter = 0; iter < cuda_utils::ceil_div(batch_size, int(blockDim.x)); iter++) {
+        int tid = iter * blockDim.x + threadIdx.x;
+        if (tid < batch_size) {
+            const int seq_start = cu_seq_lens[tid];
+            const int seq_end = cu_seq_lens[tid + 1];
+            if (token_idx >= seq_start && token_idx < seq_end) {
+                batch_idx[threadIdx.y] = tid;
+            }
+        }
+    }
+    __syncthreads();
+
+    if (head_idx >= head_dim || token_idx >= num_tokens) return;
+
+    const int inbatch_seq_idx = token_idx - cu_seq_lens[batch_idx[threadIdx.y]];
+    const int block_idx_val = block_table[batch_idx[threadIdx.y] * num_blocks +
+                                        inbatch_seq_idx / cache_block_size];
+    
+    const int64_t src_offset = block_idx_val * block_stride + 
+                               (inbatch_seq_idx % cache_block_size) * head_dim + head_idx;
+    const int64_t dst_offset = token_idx * token_stride + head_idx;
+
+    // Load from Cache
+    CacheVecType loaded_vec = *vec_ptr<const uint16_t, VEC_SIZE>(&kv_cache[src_offset]);
+    const uint16_t* loaded_raw = reinterpret_cast<const uint16_t*>(&loaded_vec);
+
+    if constexpr (std::is_same<scalar_t, at::Half>::value) {
+        *vec_ptr<scalar_t, VEC_SIZE>(&dst_k[dst_offset]) = *reinterpret_cast<DstVecType*>(&loaded_vec);
+    } else {
+        union {
+            DstVecType vec;
+            scalar_t arr[VEC_SIZE];
+        } out_buffer;
+
+        #pragma unroll
+        for(int i=0; i<VEC_SIZE; i++) {
+            // FIX: Reinterpret load safely
+            __half temp_half = *reinterpret_cast<const __half*>(&loaded_raw[i]);
+            out_buffer.arr[i] = __half2float(temp_half);
+        }
+        *vec_ptr<scalar_t, VEC_SIZE>(&dst_k[dst_offset]) = out_buffer.vec;
+    }
 }
 
 }  // namespace vllm
@@ -1237,8 +1386,8 @@ void indexer_k_quant_and_cache(
   const at::cuda::OptionalCUDAGuard device_guard(device_of(k));
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
-  DISPATCH_BY_KV_CACHE_DTYPE(k.dtype(), "fp8_e4m3",
-                             CALL_INDEXER_K_QUANT_AND_CACHE);
+      DISPATCH_BY_KV_CACHE_DTYPE(k.dtype(), "fp8_e4m3",
+                             CALL_INDEXER_K_QUANT_AND_CACHE);  
 }
 
 // Macro to dispatch the kernel based on the data amount.
@@ -1295,4 +1444,98 @@ void cp_gather_indexer_k_quant_cache(
   } else {
     CALL_CP_GATHER_INDEXER_K_QUANT_CACHE(32);
   }
+}
+
+// No quant_block_size needed, but kept in signature if you want to maintain API compatibility
+// or removed if you clean up the python side too. Here I simplified it.
+void indexer_k_cache_fp16(
+    torch::Tensor& k,               // [num_tokens, head_dim]
+    torch::Tensor& kv_cache,        // [num_blocks, block_size, cache_stride]
+    torch::Tensor& slot_mapping)    // [num_tokens]
+{
+    int num_tokens = k.size(0);
+    int head_dim = k.size(1);
+    int cache_block_size = kv_cache.size(1);
+    int cache_stride = kv_cache.size(2);
+
+    // Validate inputs
+    TORCH_CHECK(k.is_cuda(), "k must be on CUDA/ROCm");
+    TORCH_CHECK(kv_cache.is_cuda(), "kv_cache must be on CUDA/ROCm");
+    
+    // For MI50 optimization, we enforce kv_cache to be Half (Float16)
+    // We don't check k.dtype() rigorously here, we dispatch based on it.
+
+    constexpr int VEC_SIZE = 4;
+    // Grid calculation
+    dim3 grid(num_tokens, (head_dim + VEC_SIZE - 1) / VEC_SIZE); // Simple Y mapping
+    // Block dimensions: 32x4 = 128 threads (2 wavefronts on MI50)
+    dim3 block(32, VEC_SIZE); 
+    
+    const at::cuda::OptionalCUDAGuard device_guard(device_of(k));
+    const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+
+    if (k.dtype() == at::ScalarType::Float) {
+        vllm::indexer_k_cache_fp16_kernel<float><<<grid, block, 0, stream>>>(
+            k.data_ptr<float>(),
+            reinterpret_cast<uint16_t*>(kv_cache.data_ptr()),
+            slot_mapping.data_ptr<int64_t>(),
+            head_dim, cache_block_size, cache_stride);
+    } else if (k.dtype() == at::ScalarType::Half) {
+        vllm::indexer_k_cache_fp16_kernel<at::Half><<<grid, block, 0, stream>>>(
+            k.data_ptr<at::Half>(),
+            reinterpret_cast<uint16_t*>(kv_cache.data_ptr()),
+            slot_mapping.data_ptr<int64_t>(),
+            head_dim, cache_block_size, cache_stride);
+    } else {
+        TORCH_CHECK(false, "Unsupported data type for k: ", k.dtype());
+    }
+}
+
+// Host wrapper for Gather
+void cp_gather_indexer_k_cache_fp16(
+    const torch::Tensor& kv_cache,       // [num_blocks, block_size, cache_stride]
+    torch::Tensor& dst_k,                // [num_tokens, head_dim]
+    const torch::Tensor& block_table,    // [batch_size, num_blocks]
+    const torch::Tensor& cu_seq_lens     // [batch_size + 1]
+) {
+    int batch_size = block_table.size(0);
+    int num_tokens = dst_k.size(0);
+    int head_dim = dst_k.size(1);
+
+    int block_stride = kv_cache.stride(0);
+    int cache_block_size = kv_cache.size(1);
+    int num_blocks = kv_cache.size(0);
+
+    constexpr int VEC_SIZE = 4;
+    const at::cuda::OptionalCUDAGuard device_guard(device_of(kv_cache));
+    const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+
+    // Helper macro to dispatch based on token count (block Y size)
+    #define LAUNCH_GATHER(BLOCK_Y, TYPE) \
+        vllm::cp_gather_indexer_k_cache_fp16_kernel<TYPE, BLOCK_Y> \
+        <<<dim3((num_tokens + BLOCK_Y - 1) / BLOCK_Y, (head_dim + VEC_SIZE - 1) / VEC_SIZE), \
+           dim3(32, BLOCK_Y), 0, stream>>>( \
+            reinterpret_cast<uint16_t*>(kv_cache.data_ptr()), \
+            dst_k.data_ptr<TYPE>(), \
+            block_table.data_ptr<int32_t>(), \
+            cu_seq_lens.data_ptr<int32_t>(), \
+            batch_size, dst_k.stride(0), head_dim, \
+            block_stride, cache_block_size, num_blocks, num_tokens)
+
+    // Select dispatch type
+    if (dst_k.dtype() == at::ScalarType::Float) {
+        if (num_tokens < 32) { LAUNCH_GATHER(1, float); }
+        else if (num_tokens < 64) { LAUNCH_GATHER(2, float); }
+        else if (num_tokens < 128) { LAUNCH_GATHER(4, float); }
+        else if (num_tokens < 256) { LAUNCH_GATHER(8, float); }
+        else { LAUNCH_GATHER(16, float); }
+    } else if (dst_k.dtype() == at::ScalarType::Half) {
+        if (num_tokens < 32) { LAUNCH_GATHER(1, at::Half); }
+        else if (num_tokens < 64) { LAUNCH_GATHER(2, at::Half); }
+        else if (num_tokens < 128) { LAUNCH_GATHER(4, at::Half); }
+        else if (num_tokens < 256) { LAUNCH_GATHER(8, at::Half); }
+        else { LAUNCH_GATHER(16, at::Half); }
+    } else {
+        TORCH_CHECK(false, "Unsupported dst_k dtype");
+    }
 }

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -102,13 +102,16 @@ void apply_repetition_penalties_(torch::Tensor& logits,
                                  const torch::Tensor& output_mask,
                                  const torch::Tensor& repetition_penalties);
 
-void top_k_per_row(const torch::Tensor& logits, const torch::Tensor& rowStarts,
-                   const torch::Tensor& rowEnds, torch::Tensor& indices,
-                   int64_t numRows, int64_t stride0, int64_t stride1);
+void top_k_per_row_prefill(const torch::Tensor& logits,
+                           const torch::Tensor& rowStarts,
+                           const torch::Tensor& rowEnds, torch::Tensor& indices,
+                           int64_t numRows, int64_t stride0, int64_t stride1,
+                           int64_t topK);
 
 void top_k_per_row_decode(const torch::Tensor& logits, int64_t next_n,
-                          const torch::Tensor& seq_lens, torch::Tensor& indices,
-                          int64_t numRows, int64_t stride0, int64_t stride1);
+                          const torch::Tensor& seqLens, torch::Tensor& indices,
+                          int64_t numRows, int64_t stride0, int64_t stride1,
+                          int64_t topK);
 
 void rms_norm_static_fp8_quant(torch::Tensor& out, torch::Tensor& input,
                                torch::Tensor& weight, torch::Tensor& scale,

--- a/csrc/sampler.cu
+++ b/csrc/sampler.cu
@@ -44,40 +44,299 @@ __global__ void apply_repetition_penalties_kernel(
   }
 }
 
-static inline __device__ uint16_t extractBinIdx(float x) {
-  union {
-    __half h;
-    uint16_t u16;
-  } tmp;
-  tmp.h = __float2half_rn(x);
-  tmp.u16 = (x < 0.f) ? (~tmp.u16 & 0xffff) : (tmp.u16 | 0x8000);
-  return 511 - (tmp.u16 >> 7);
+__device__ __forceinline__ auto convert_to_uint32(float x) -> uint32_t {
+  uint32_t bits = __float_as_uint(x);
+  return (bits & 0x80000000) ? bits : ~bits & 0x7fffffff;
 }
 
-template <int kNumThreadsPerBlock = 512, int kNumBins = 512, int kTopK = 2048>
-__device__ void topKPerRowJob(const float* logits, const int rowStart,
-                              const int rowEnd, const int rowIdx,
-                              int* outIndices, int stride0, int stride1) {
-  // The number of elements per thread for the final top-k sort.
-  static constexpr int kNumTopKItemsPerThread = kTopK / kNumThreadsPerBlock;
-  // The class to sort the elements during the final top-k sort.
-  using TopKSort = cub::BlockRadixSort<float, kNumThreadsPerBlock,
-                                       kNumTopKItemsPerThread, int>;
+template <int step>
+static inline __device__ uint32_t extractBinIdx(float x) {
+  if constexpr (step == 0) {
+    __half hx = __float2half(x);
+    uint16_t bits = __half_as_ushort(hx);
+    bits = (bits & 0x8000) ? bits : ~bits & 0x7fff;
+    return bits >> 5;
+  } else {
+    uint32_t bits = __float_as_uint(x);
+    bits = (bits & 0x80000000) ? bits : ~bits & 0x7fffffff;
 
+    if constexpr (step == 1) {
+      return bits >> 21;
+    } else if constexpr (step == 2) {
+      return (bits >> 10) & 0x7ff;
+    } else if constexpr (step == 3) {
+      return bits & 0x3ff;
+    }
+  }
+}
+
+template <int shift>
+static inline __device__ bool isPartialMatch(float x, uint32_t pattern) {
+  if constexpr (shift == 0) {
+    return true;
+  }
+  uint32_t bits = __float_as_uint(x);
+  bits = (bits & 0x80000000) ? bits : ~bits & 0x7fffffff;
+  return (bits ^ pattern) >> shift == 0;
+}
+
+/**
+ * Map a Func over the input data, using vectorized load instructions if
+ * possible.
+ *
+ * @tparam T element type
+ * @tparam IdxT indexing type
+ * @tparam Func void (T x, IdxT idx)
+ *
+ * @param thread_rank rank of the calling thread among all participating threads
+ * @param num_threads number of the threads that participate in processing
+ * @param in the input data
+ * @param len the number of elements to read
+ * @param f the lambda taking two arguments (T x, IdxT idx)
+ */
+template <typename T, typename idxT, typename Func>
+__device__ void vectorized_process(size_t thread_rank, size_t num_threads,
+                                   const T* in, idxT len, Func f) {
+  constexpr int WARP_SIZE = 32;
+  using WideT = float4;
+  if constexpr (sizeof(T) >= sizeof(WideT)) {
+    for (idxT i = thread_rank; i < len; i += num_threads) {
+      f(in[i], i);
+    }
+  } else {
+    static_assert(sizeof(WideT) % sizeof(T) == 0);
+    constexpr int items_per_scalar = sizeof(WideT) / sizeof(T);
+    // TODO: it's UB
+    union {
+      WideT scalar;
+      T array[items_per_scalar];
+    } wide;
+
+    int skip_cnt =
+        (reinterpret_cast<size_t>(in) % sizeof(WideT))
+            ? ((sizeof(WideT) - reinterpret_cast<size_t>(in) % sizeof(WideT)) /
+               sizeof(T))
+            : 0;
+    if (skip_cnt > len) {
+      skip_cnt = len;
+    }
+    const WideT* in_cast = reinterpret_cast<decltype(in_cast)>(in + skip_cnt);
+    const idxT len_cast = (len - skip_cnt) / items_per_scalar;
+
+    for (idxT i = thread_rank; i < len_cast; i += num_threads) {
+      wide.scalar = in_cast[i];
+      const idxT real_i = skip_cnt + i * items_per_scalar;
+#pragma unroll
+      for (int j = 0; j < items_per_scalar; ++j) {
+        f(wide.array[j], real_i + j);
+      }
+    }
+
+    static_assert(WARP_SIZE >= items_per_scalar);
+    // and because items_per_scalar > skip_cnt, WARP_SIZE > skip_cnt
+    // no need to use loop
+    if (thread_rank < skip_cnt) {
+      f(in[thread_rank], thread_rank);
+    }
+    // because len_cast = (len - skip_cnt) / items_per_scalar,
+    // len_cast * items_per_scalar + items_per_scalar > len - skip_cnt;
+    // and so
+    // len - (skip_cnt + len_cast * items_per_scalar) < items_per_scalar <=
+    // WARP_SIZE no need to use loop
+    const idxT remain_i = skip_cnt + len_cast * items_per_scalar + thread_rank;
+    if (remain_i < len) {
+      f(in[remain_i], remain_i);
+    }
+  }
+}
+
+template <int step, int kNumThreadsPerBlock, int kNumBins, int kNumFinalItems,
+          bool multipleBlocksPerRow, bool mergeBlocks, typename SmemFinalType,
+          typename SmemOutputType>
+__device__ bool processHistogramStep(
+    const int* indices, const float* logits, int rowEnd, uint32_t& logitPattern,
+    int& thresholdBinIdx, SmemOutputType& smemOutput, int* smemThresholdBinIdx,
+    int* smemFinalDstIdx, int* smemFinalBinSize, int* smemFoundTopKValues,
+    SmemFinalType& smemFinal, int stride1, int rowStart, int topK) {
+  // Clear the histogram.
+#pragma unroll
+  for (int idx = threadIdx.x; idx < kNumBins; idx += kNumThreadsPerBlock) {
+    smemFinal.histo.data[idx] = 0;
+  }
+
+  // Make sure the histogram is ready.
+  __syncthreads();
+
+  // Update pattern
+  constexpr auto patternShift = step < 2 ? 0 : step == 2 ? 21 : 10;
+  if constexpr (step == 2) {
+    logitPattern = static_cast<uint32_t>(thresholdBinIdx & 0x7ff)
+                   << patternShift;
+  } else if constexpr (step == 3) {
+    logitPattern |= static_cast<uint32_t>(thresholdBinIdx & 0x7ff)
+                    << patternShift;
+  }
+
+  auto distributeToBins = [&](float logit, int /* idx */ = 0) {
+    if (isPartialMatch<patternShift>(logit, logitPattern)) {
+      uint32_t binIdx = extractBinIdx<step>(logit);
+      atomicAdd(&smemFinal.histo.data[binIdx], 1);
+    }
+  };
+
+  // Distribute the elements to the histogram bins.
+  if (stride1 == 1) {
+    vectorized_process(threadIdx.x, kNumThreadsPerBlock, logits + rowStart,
+                       rowEnd - rowStart, distributeToBins);
+  } else {
+    for (int idx = rowStart + threadIdx.x; idx < rowEnd;
+         idx += kNumThreadsPerBlock) {
+      float logit = logits[idx * stride1];
+      distributeToBins(logit, idx);
+    }
+  }
+  // Make sure the histogram is ready.
+  __syncthreads();
+
+  // Reads the value of the starting position in the smemOutput array
+  int lastValue = smemFoundTopKValues[0];
+
+  for (int round = 0; round < kNumBins / kNumThreadsPerBlock; round++) {
+    // Read the values from SMEM.
+    int idx = threadIdx.x + kNumThreadsPerBlock * round;
+    int binCount{0};
+    binCount = smemFinal.histo.data[idx];
+
+    // Make sure each thread has read its value.
+    __syncthreads();
+
+    // Compute the prefix sum.
+    int prefixSum{0}, totalSum{0};
+    using Scan = cub::BlockScan<int, kNumThreadsPerBlock>;
+    Scan(smemFinal.histo.scan).ExclusiveSum(binCount, prefixSum, totalSum);
+
+    // Update the histogram with the prefix sums.
+    prefixSum += lastValue;
+    totalSum += lastValue;
+    smemFinal.histo.data[idx] = prefixSum;
+
+    // Make sure the data is in shared memory.
+    __syncthreads();
+
+    // Find the last valid bin.
+    bool foundThreshold = false;
+    if (prefixSum < topK) {
+      int nextPrefixSum = threadIdx.x == kNumThreadsPerBlock - 1
+                              ? totalSum
+                              : smemFinal.histo.data[idx + 1];
+
+      if (nextPrefixSum >= topK) {
+        smemThresholdBinIdx[0] = idx;
+        smemFinalBinSize[0] = nextPrefixSum - prefixSum;
+        foundThreshold = true;
+      }
+    }
+
+    // Early exit: if any thread found the threshold, we can skip remaining
+    // rounds
+    if (__syncthreads_or(foundThreshold)) {
+      break;
+    }
+
+    lastValue = totalSum;
+  }
+
+  // Make sure the data is in shared memory.
+  __syncthreads();
+
+  // The threshold bin.
+  thresholdBinIdx = smemThresholdBinIdx[0];
+
+  auto processBins = [&](float logit, int idx) {
+    if (isPartialMatch<patternShift>(logit, logitPattern)) {
+      uint32_t binIdx = extractBinIdx<step>(logit);
+      if (binIdx < thresholdBinIdx) {
+        // The element is part of the top-k selection
+        int dstIdx = atomicAdd(&smemFoundTopKValues[0], 1);
+
+        if constexpr (mergeBlocks) {
+          smemOutput[dstIdx] = indices[idx];
+        } else if constexpr (multipleBlocksPerRow) {
+          smemOutput[dstIdx] = idx + rowStart;
+          reinterpret_cast<float*>(smemOutput + topK)[dstIdx] = logit;
+        } else {
+          smemOutput[dstIdx] = idx;
+        }
+      }
+      if constexpr (step < 3) {
+        // Only fill the final items for sorting if the threshold bin fits
+        if (binIdx == thresholdBinIdx &&
+            smemFinalBinSize[0] <= kNumFinalItems) {
+          int dstIdx = atomicAdd(&smemFinalDstIdx[0], 1);
+          smemFinal.items.logits[dstIdx] = logit;
+          if constexpr (mergeBlocks) {
+            smemFinal.items.indices[dstIdx] = indices[idx];
+          } else if constexpr (multipleBlocksPerRow) {
+            smemFinal.items.indices[dstIdx] = idx + rowStart;
+          } else {
+            smemFinal.items.indices[dstIdx] = idx;
+          }
+        }
+      } else {
+        if (binIdx == thresholdBinIdx) {
+          // The elements in the threshold bin share the same 32 bits at step 3
+          int dstIdx = atomicAdd(&smemFinal.histo.data[binIdx], 1);
+          if (dstIdx < topK) {
+            if constexpr (mergeBlocks) {
+              smemOutput[dstIdx] = indices[idx];
+            } else if constexpr (multipleBlocksPerRow) {
+              smemOutput[dstIdx] = idx + rowStart;
+              reinterpret_cast<float*>(smemOutput + topK)[dstIdx] = logit;
+            } else {
+              smemOutput[dstIdx] = idx;
+            }
+          }
+        }
+      }
+    }
+  };
+
+  if (stride1 == 1) {
+    vectorized_process(threadIdx.x, kNumThreadsPerBlock, logits + rowStart,
+                       rowEnd - rowStart, processBins);
+  } else {
+    for (int idx = rowStart + threadIdx.x; idx < rowEnd;
+         idx += kNumThreadsPerBlock) {
+      float logit = logits[idx * stride1];
+      processBins(logit, idx);
+    }
+  }
+
+  // Make sure the elements are in shared memory.
+  __syncthreads();
+
+  // Check if we should continue to next step
+  return smemFinalBinSize[0] > kNumFinalItems;
+}
+
+// Follows half - 11 - 11 - 10 bit iterations
+template <int kNumThreadsPerBlock, int kNumBins, bool useRadixSort,
+          bool multipleBlocksPerRow = false, bool mergeBlocks = false>
+static __device__ void topKPerRowJob(const int* indices, const float* logits,
+                                     int rowStart, int rowEnd, int* outIndices,
+                                     float* outLogits, int stride1, int topK) {
   // The number of slots for the final pass.
-  static constexpr int kNumFinalItems = 3072;
+  static constexpr int kNumFinalItems = 2048;
   // The number of elements per thread for the final sort.
   static constexpr int kNumFinalItemsPerThread =
       kNumFinalItems / kNumThreadsPerBlock;
   // The class to sort the elements during the final pass.
   using FinalSort = cub::BlockRadixSort<float, kNumThreadsPerBlock,
                                         kNumFinalItemsPerThread, int>;
-
+  using FinalSortTempStorage =
+      std::conditional_t<useRadixSort, typename FinalSort::TempStorage, int>;
   // The class to compute the inclusive prefix-sum over the histogram.
   using Scan = cub::BlockScan<int, kNumThreadsPerBlock>;
-
-  // Shared memory to compute the block scan.
-  __shared__ typename Scan::TempStorage smemScan;
 
   // The structure to store the final items (for the final pass).
   struct FinalItems {
@@ -87,200 +346,225 @@ __device__ void topKPerRowJob(const float* logits, const int rowStart,
     float logits[kNumFinalItems];
   };
 
+  struct Histogram {
+    typename Scan::TempStorage scan;
+    int data[kNumBins];
+  };
+
   // Shared memory to compute the block sort.
   __shared__ union {
     FinalItems items;
-    typename FinalSort::TempStorage finalSort;
-    typename TopKSort::TempStorage topKSort;
+    FinalSortTempStorage finalSort;
+    Histogram histo;
   } smemFinal;
 
-  // Shared memory to store the histogram.
-  __shared__ int smemHistogram[kNumBins];
   // Shared memory to store the selected indices.
-  __shared__ int smemIndices[kTopK];
+  // If we are processing using multiple blocks, we need to store the logits and
+  // indices.
+  extern __shared__ int32_t smemOutput[];
+
   // Shared memory to store the threshold bin.
   __shared__ int smemThresholdBinIdx[1];
   // Shared memory counter to register the candidates for the final phase.
   __shared__ int smemFinalDstIdx[1];
+  // Shared memory to determine if the threshold bin fits in the final items.
+  __shared__ int smemFinalBinSize[1];
+  // Shared memory to keep track of the top-k values found so far by the
+  // previous iterations
+  __shared__ int smemFoundTopKValues[1];
 
   // The length of the row.
   int rowLen = rowEnd - rowStart;
 
   // Shortcut if the length of the row is smaller than Top-K. Indices are not
   // sorted by their corresponding logit.
-  if (rowLen <= kTopK) {
+  if (rowLen <= topK) {
     for (int rowIt = threadIdx.x; rowIt < rowLen;
          rowIt += kNumThreadsPerBlock) {
-      int idx = rowStart + rowIt;
-      outIndices[rowIdx * kTopK + rowIt] = idx - rowStart;
+      if constexpr (multipleBlocksPerRow) {
+        outIndices[rowIt] = rowIt + rowStart;
+        outLogits[rowIt] = logits[rowIt + rowStart];
+      } else {
+        outIndices[rowIt] = rowIt;
+      }
     }
-    for (int rowIt = rowLen + threadIdx.x; rowIt < kTopK;
+    for (int rowIt = rowLen + threadIdx.x; rowIt < topK;
          rowIt += kNumThreadsPerBlock) {
-      outIndices[rowIdx * kTopK + rowIt] = -1;
+      outIndices[rowIt] = -1;
+      if constexpr (multipleBlocksPerRow) {
+        outLogits[rowIt] = -FLT_MAX;
+      }
     }
+
     return;
   }
-
-  // Clear the histogram.
-  if (threadIdx.x < kNumBins) {
-    smemHistogram[threadIdx.x] = 0;
-  }
-
-  // Make sure the histogram is ready.
-  __syncthreads();
-
-  // Fetch elements one-by-one.
-  for (int rowIt = rowStart + threadIdx.x; rowIt < rowEnd;
-       rowIt += kNumThreadsPerBlock) {
-    uint16_t idx = extractBinIdx(logits[rowIdx * stride0 + rowIt * stride1]);
-    atomicAdd(&smemHistogram[idx], 1);
-  }
-
-  // Make sure the histogram is ready.
-  __syncthreads();
-
-  // Read the values from SMEM.
-  int binCount{0};
-  if (threadIdx.x < kNumBins) {
-    binCount = smemHistogram[threadIdx.x];
-  }
-
-  // Make sure each thread has read its value.
-  __syncthreads();
-
-  // Compute the prefix sum.
-  int prefixSum{0}, totalSum{0};
-  Scan(smemScan).ExclusiveSum(binCount, prefixSum, totalSum);
-
-  // Update the histogram with the prefix sums.
-  if (threadIdx.x < kNumBins) {
-    smemHistogram[threadIdx.x] = prefixSum;
-  }
-
-  // Make sure the data is in shared memory.
-  __syncthreads();
-
-  // Find the last valid bin.
-  if (threadIdx.x < kNumBins) {
-    int nextPrefixSum =
-        threadIdx.x == kNumBins - 1 ? totalSum : smemHistogram[threadIdx.x + 1];
-    if (prefixSum < kTopK && nextPrefixSum >= kTopK) {
-      smemThresholdBinIdx[0] = threadIdx.x;
-    }
-  }
-
-  // Clear the counter to store the items for the final phase.
+  // Initialize values
   if (threadIdx.x == 0) {
     smemFinalDstIdx[0] = 0;
+    smemFoundTopKValues[0] = 0;
+  }
+  __syncthreads();
+  int thresholdBinIdx = -1;
+  uint32_t logitPattern = 0;
+
+  // Step 0: Process first 11 bits of half representation
+  bool continueToNextStep =
+      processHistogramStep<0, kNumThreadsPerBlock, kNumBins, kNumFinalItems,
+                           multipleBlocksPerRow, mergeBlocks>(
+          indices, logits, rowEnd, logitPattern, thresholdBinIdx, smemOutput,
+          smemThresholdBinIdx, smemFinalDstIdx, smemFinalBinSize,
+          smemFoundTopKValues, smemFinal, stride1, rowStart, topK);
+
+  if (continueToNextStep) {
+    // Step 1: Process next 11 bits
+    continueToNextStep =
+        processHistogramStep<1, kNumThreadsPerBlock, kNumBins, kNumFinalItems,
+                             multipleBlocksPerRow, mergeBlocks>(
+            indices, logits, rowEnd, logitPattern, thresholdBinIdx, smemOutput,
+            smemThresholdBinIdx, smemFinalDstIdx, smemFinalBinSize,
+            smemFoundTopKValues, smemFinal, stride1, rowStart, topK);
   }
 
-  // Make sure the data is in shared memory.
-  __syncthreads();
+  if (continueToNextStep) {
+    // Step 2: Process next 11 bits
+    continueToNextStep =
+        processHistogramStep<2, kNumThreadsPerBlock, kNumBins, kNumFinalItems,
+                             multipleBlocksPerRow, mergeBlocks>(
+            indices, logits, rowEnd, logitPattern, thresholdBinIdx, smemOutput,
+            smemThresholdBinIdx, smemFinalDstIdx, smemFinalBinSize,
+            smemFoundTopKValues, smemFinal, stride1, rowStart, topK);
+  }
 
-  // The threshold bin.
-  int thresholdBinIdx = smemThresholdBinIdx[0];
+  if (continueToNextStep) {
+    // Step 3: Process last 10 bits
+    processHistogramStep<3, kNumThreadsPerBlock, kNumBins, kNumFinalItems,
+                         multipleBlocksPerRow, mergeBlocks>(
+        indices, logits, rowEnd, logitPattern, thresholdBinIdx, smemOutput,
+        smemThresholdBinIdx, smemFinalDstIdx, smemFinalBinSize,
+        smemFoundTopKValues, smemFinal, stride1, rowStart, topK);
+  }
 
-  // Fetch elements one-by-one and populate the shared memory buffers.
-  for (int rowIt = rowStart + threadIdx.x; rowIt < rowEnd;
-       rowIt += kNumThreadsPerBlock) {
-    float logit = logits[rowIdx * stride0 + rowIt * stride1];
-    uint16_t idx = extractBinIdx(logit);
-    if (idx < thresholdBinIdx) {
-      int dstIdx = atomicAdd(&smemHistogram[idx], 1);
-      smemIndices[dstIdx] = rowIt;
-    } else if (idx == thresholdBinIdx) {
-      int dstIdx = atomicAdd(&smemFinalDstIdx[0], 1);
-      if (dstIdx < kNumFinalItems) {
-        smemFinal.items.logits[dstIdx] = logit;
-        smemFinal.items.indices[dstIdx] = rowIt;
+  if (!continueToNextStep) {
+    // The histogram did not proceed to the final 10 bits, therefore we need to
+    // sort the final items The logits of the elements to be sorted in the final
+    // pass.
+    if constexpr (useRadixSort) {
+      // Sorting with radix sort
+      float finalLogits[kNumFinalItemsPerThread];
+      // The indices of the elements to be sorted in the final pass.
+      int finalIndices[kNumFinalItemsPerThread];
+
+#pragma unroll
+      for (int ii = 0; ii < kNumFinalItemsPerThread; ++ii) {
+        finalLogits[ii] = -FLT_MAX;
+      }
+
+      // Read the elements from SMEM.
+#pragma unroll
+      for (int ii = 0; ii < kNumFinalItemsPerThread; ++ii) {
+        int srcIdx = ii * kNumThreadsPerBlock + threadIdx.x;
+        if (srcIdx < smemFinalDstIdx[0]) {
+          finalLogits[ii] = smemFinal.items.logits[srcIdx];
+          finalIndices[ii] = smemFinal.items.indices[srcIdx];
+        }
+      }
+      // Make sure the shared memory has been read.
+      __syncthreads();
+
+      // Sort the elements.
+      FinalSort(smemFinal.finalSort)
+          .SortDescendingBlockedToStriped(finalLogits, finalIndices);
+
+      // Copy the data back to the shared memory storage.
+      int baseIdx = smemFoundTopKValues[0];
+
+#pragma unroll
+      for (int ii = 0; ii < kNumFinalItemsPerThread; ++ii) {
+        int srcIdx = ii * kNumThreadsPerBlock + threadIdx.x;
+        int dstIdx = baseIdx + srcIdx;
+
+        if (dstIdx < topK) {
+          smemOutput[dstIdx] = finalIndices[ii];
+          if constexpr (multipleBlocksPerRow) {
+            reinterpret_cast<float*>(smemOutput + topK)[dstIdx] =
+                finalLogits[ii];
+          }
+        }
+      }
+    } else {
+      // Sorting with insertion sort
+      auto baseIdx = smemFoundTopKValues[0];
+      for (int i = threadIdx.x; i < smemFinalDstIdx[0];
+           i += kNumThreadsPerBlock) {
+        int outIndex = 0;
+        auto logit = smemFinal.items.logits[i];
+        for (int j = 0; j < smemFinalDstIdx[0]; j++) {
+          auto otherLogit = smemFinal.items.logits[j];
+          if (logit < otherLogit || (logit == otherLogit && i < j)) {
+            outIndex++;
+          }
+        }
+        // Store if outIndex is in bounds
+        if (outIndex + baseIdx < topK) {
+          smemOutput[outIndex + baseIdx] = smemFinal.items.indices[i];
+          if constexpr (multipleBlocksPerRow) {
+            reinterpret_cast<float*>(smemOutput + topK)[outIndex + baseIdx] =
+                smemFinal.items.logits[i];
+          }
+        }
+      }
+    }
+    __syncthreads();
+  }
+
+  // Store to global memory.
+  for (int i = threadIdx.x; i < topK; i += kNumThreadsPerBlock) {
+    if constexpr (multipleBlocksPerRow) {
+      outIndices[i] = smemOutput[i];
+      outLogits[i] = reinterpret_cast<float*>(smemOutput + topK)[i];
+    } else {
+      if (stride1 == 1) {
+        // stride1 == 1 will use vectorized_process, which indexes already skip
+        // the rowStart.
+        outIndices[i] = smemOutput[i];
+      } else {
+        outIndices[i] = smemOutput[i] - rowStart;
       }
     }
   }
-
-  // Make sure the elements are in shared memory.
-  __syncthreads();
-
-  // The logits of the elements to be sorted in the final pass.
-  float finalLogits[kNumFinalItemsPerThread];
-  // The indices of the elements to be sorted in the final pass.
-  int finalIndices[kNumFinalItemsPerThread];
-
-// Init.
-#pragma unroll
-  for (int ii = 0; ii < kNumFinalItemsPerThread; ++ii) {
-    finalLogits[ii] = -FLT_MAX;
-  }
-
-// Read the elements from SMEM.
-#pragma unroll
-  for (int ii = 0; ii < kNumFinalItemsPerThread; ++ii) {
-    int srcIdx = ii * kNumThreadsPerBlock + threadIdx.x;
-    if (srcIdx < smemFinalDstIdx[0]) {
-      finalLogits[ii] = smemFinal.items.logits[srcIdx];
-      finalIndices[ii] = smemFinal.items.indices[srcIdx];
-    }
-  }
-
-  // Make sure the shared memory has been read.
-  __syncthreads();
-
-  // Sort the elements.
-  FinalSort(smemFinal.finalSort)
-      .SortDescendingBlockedToStriped(finalLogits, finalIndices);
-
-  // Copy the data back to the shared memory storage.
-  int baseIdx = thresholdBinIdx > 0 ? smemHistogram[thresholdBinIdx - 1] : 0;
-#pragma unroll
-  for (int ii = 0; ii < kNumFinalItemsPerThread; ++ii) {
-    int srcIdx = ii * kNumThreadsPerBlock + threadIdx.x;
-    int dstIdx = baseIdx + srcIdx;
-    if (dstIdx < kTopK) {
-      smemIndices[dstIdx] = finalIndices[ii];
-    }
-  }
-
-  // Make sure the data is in shared memory.
-  __syncthreads();
-
-// Store to global memory.
-#pragma unroll
-  for (int ii = 0; ii < kNumTopKItemsPerThread; ++ii) {
-    int offset = rowIdx * kTopK + ii * kNumThreadsPerBlock + threadIdx.x;
-    outIndices[offset] =
-        smemIndices[ii * kNumThreadsPerBlock + threadIdx.x] - rowStart;
-  }
 }
 
-template <int kNumThreadsPerBlock = 512>
-static __global__ void topKPerRow(const float* logits, const int* rowStarts,
-                                  const int* rowEnds, int* outIndices,
-                                  int stride0, int stride1) {
+template <int kNumThreadsPerBlock, bool useRadixSort>
+static __global__ __launch_bounds__(kNumThreadsPerBlock) void topKPerRowPrefill(
+    const float* logits, const int* rowStarts, const int* rowEnds,
+    int* outIndices, int stride0, int stride1, const int topK,
+    const int offsetIndex) {
   // The number of bins in the histogram.
-  static constexpr int kNumBins = 512;
-
-  // The top-k width.
-  static constexpr int kTopK = 2048;
+  static constexpr int kNumBins = 2048;
 
   // The row computed by this block.
-  int rowIdx = blockIdx.x;
+  int rowIdx = blockIdx.x + offsetIndex;
 
   // The range of logits within the row.
   int rowStart = rowStarts[rowIdx];
   int rowEnd = rowEnds[rowIdx];
 
-  topKPerRowJob<kNumThreadsPerBlock, kNumBins, kTopK>(
-      logits, rowStart, rowEnd, rowIdx, outIndices, stride0, stride1);
+  // Local pointers to this block
+  outIndices += rowIdx * topK;
+  logits += rowIdx * stride0;
+
+  topKPerRowJob<kNumThreadsPerBlock, kNumBins, useRadixSort>(
+      nullptr, logits, rowStart, rowEnd, outIndices, nullptr, stride1, topK);
 }
 
-template <int kNumThreadsPerBlock = 512>
-static __global__ void topKPerRowDecode(const float* logits, const int* seqLens,
-                                        int* outIndices, int stride0,
-                                        int stride1, int next_n) {
+template <int kNumThreadsPerBlock, bool useRadixSort,
+          bool multipleBlocksPerRow = false, bool mergeBlocks = false>
+static __global__ __launch_bounds__(kNumThreadsPerBlock) void topKPerRowDecode(
+    const float* logits, const int* seqLens, int* outIndices, int stride0,
+    int stride1, const int topK, int next_n, float* outLogits = nullptr,
+    const int numBlocksToMerge = 0, const int* indices = nullptr) {
   // The number of bins in the histogram.
-  static constexpr int kNumBins = 512;
-
-  // The top-k width.
-  static constexpr int kTopK = 2048;
+  static constexpr int kNumBins = 2048;
 
   // The row computed by this block.
   int rowIdx = blockIdx.x;
@@ -290,8 +574,25 @@ static __global__ void topKPerRowDecode(const float* logits, const int* seqLens,
   int seq_len = seqLens[rowIdx / next_n];
   int rowEnd = seq_len - next_n + (rowIdx % next_n) + 1;
 
-  topKPerRowJob<kNumThreadsPerBlock, kNumBins, kTopK>(
-      logits, rowStart, rowEnd, rowIdx, outIndices, stride0, stride1);
+  // Local pointers to this block
+  if constexpr (!multipleBlocksPerRow && !mergeBlocks) {
+    outIndices += rowIdx * topK;
+  } else if constexpr (multipleBlocksPerRow) {
+    const auto blockSize = rowEnd / gridDim.y;  // 16384 / 2 = 8192
+    rowStart = blockSize * blockIdx.y;          // 8192 * 1 = 8192
+    rowEnd = gridDim.y == blockIdx.y + 1 ? rowEnd : rowStart + blockSize;
+    outIndices += rowIdx * gridDim.y * topK + blockIdx.y * topK;
+    outLogits += rowIdx * gridDim.y * topK + blockIdx.y * topK;
+  } else if constexpr (mergeBlocks) {
+    rowEnd = numBlocksToMerge * topK;
+    indices += rowIdx * numBlocksToMerge * topK;
+    outIndices += rowIdx * topK;
+  }
+  logits += rowIdx * stride0;
+
+  topKPerRowJob<kNumThreadsPerBlock, kNumBins, useRadixSort,
+                multipleBlocksPerRow, mergeBlocks>(
+      indices, logits, rowStart, rowEnd, outIndices, outLogits, stride1, topK);
 }
 
 }  // namespace vllm
@@ -339,28 +640,84 @@ void apply_repetition_penalties_(
 
 void top_k_per_row_decode(const torch::Tensor& logits, int64_t next_n,
                           const torch::Tensor& seqLens, torch::Tensor& indices,
-                          int64_t numRows, int64_t stride0, int64_t stride1) {
-  // Compute the results on the device.
+                          int64_t numRows, int64_t stride0, int64_t stride1,
+                          int64_t topK) {
+  constexpr int kSortingAlgorithmThreshold = 12288;
+  constexpr int kSplitWorkThreshold = 200 * 1000;
   constexpr int kNumThreadsPerBlock = 512;
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  const auto numColumns = logits.size(1);
 
-  vllm::topKPerRowDecode<kNumThreadsPerBlock>
-      <<<numRows, kNumThreadsPerBlock, 0, stream>>>(
-          logits.data_ptr<float>(), seqLens.data_ptr<int>(),
-          indices.data_ptr<int>(), static_cast<int>(stride0),
-          static_cast<int>(stride1), static_cast<int>(next_n));
+  if (numColumns < kSortingAlgorithmThreshold) {
+    // Use insertion sort
+    vllm::topKPerRowDecode<kNumThreadsPerBlock, false>
+        <<<numRows, kNumThreadsPerBlock, topK * sizeof(int32_t), stream>>>(
+            logits.data_ptr<float>(), seqLens.data_ptr<int>(),
+            indices.data_ptr<int>(), static_cast<int>(stride0),
+            static_cast<int>(stride1), static_cast<int>(topK),
+            static_cast<int>(next_n));
+  } else if (numColumns < kSplitWorkThreshold) {
+    // From this threshold, use radix sort instead
+    vllm::topKPerRowDecode<kNumThreadsPerBlock, true>
+        <<<numRows, kNumThreadsPerBlock, topK * sizeof(int32_t), stream>>>(
+            logits.data_ptr<float>(), seqLens.data_ptr<int>(),
+            indices.data_ptr<int>(), static_cast<int>(stride0),
+            static_cast<int>(stride1), static_cast<int>(topK),
+            static_cast<int>(next_n));
+  } else {
+    // Long sequences are run in two steps
+    constexpr auto multipleBlocksPerRowConfig = 10;
+
+    const auto outIndicesAux =
+        torch::empty({numRows, multipleBlocksPerRowConfig, topK},
+                     torch::dtype(torch::kInt32).device(logits.device()));
+    const auto outLogitsAux =
+        torch::empty({numRows, multipleBlocksPerRowConfig, topK},
+                     torch::dtype(torch::kFloat).device(logits.device()));
+
+    vllm::topKPerRowDecode<kNumThreadsPerBlock, true, true>
+        <<<dim3(numRows, multipleBlocksPerRowConfig), kNumThreadsPerBlock,
+           2 * topK * sizeof(int32_t), stream>>>(
+            logits.data_ptr<float>(), seqLens.data_ptr<int>(),
+            outIndicesAux.data_ptr<int>(), static_cast<int>(stride0),
+            static_cast<int>(stride1), static_cast<int>(topK),
+            static_cast<int>(next_n), outLogitsAux.data_ptr<float>());
+
+    constexpr int kNumThreadsPerBlockMerge = 1024;
+    vllm::topKPerRowDecode<kNumThreadsPerBlockMerge, true, false, true>
+        <<<numRows, kNumThreadsPerBlockMerge, topK * sizeof(int32_t), stream>>>(
+            outLogitsAux.data_ptr<float>(), seqLens.data_ptr<int>(),
+            indices.data_ptr<int>(), multipleBlocksPerRowConfig * topK, 1,
+            static_cast<int>(topK), static_cast<int>(next_n), nullptr,
+            multipleBlocksPerRowConfig, outIndicesAux.data_ptr<int>());
+  }
 }
 
-void top_k_per_row(const torch::Tensor& logits, const torch::Tensor& rowStarts,
-                   const torch::Tensor& rowEnds, torch::Tensor& indices,
-                   int64_t numRows, int64_t stride0, int64_t stride1) {
-  // Compute the results on the device.
+void top_k_per_row_prefill(const torch::Tensor& logits,
+                           const torch::Tensor& rowStarts,
+                           const torch::Tensor& rowEnds, torch::Tensor& indices,
+                           int64_t numRows, int64_t stride0, int64_t stride1,
+                           int64_t topK) {
+  constexpr int kSortingAlgorithmThreshold = 12288;
   constexpr int kNumThreadsPerBlock = 512;
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
-  vllm::topKPerRow<kNumThreadsPerBlock>
-      <<<numRows, kNumThreadsPerBlock, 0, stream>>>(
-          logits.data_ptr<float>(), rowStarts.data_ptr<int>(),
-          rowEnds.data_ptr<int>(), indices.data_ptr<int>(),
-          static_cast<int>(stride0), static_cast<int>(stride1));
+  int numInsertionBlocks =
+      std::min(static_cast<int>(numRows), kSortingAlgorithmThreshold);
+  vllm::topKPerRowPrefill<kNumThreadsPerBlock, false>
+      <<<numInsertionBlocks, kNumThreadsPerBlock, topK * sizeof(int32_t),
+         stream>>>(logits.data_ptr<float>(), rowStarts.data_ptr<int>(),
+                   rowEnds.data_ptr<int>(), indices.data_ptr<int>(),
+                   static_cast<int>(stride0), static_cast<int>(stride1),
+                   static_cast<int>(topK), 0);
+
+  if (numRows > kSortingAlgorithmThreshold) {
+    int numRadixBlocks = numRows - kSortingAlgorithmThreshold;
+    vllm::topKPerRowPrefill<kNumThreadsPerBlock, true>
+        <<<numRadixBlocks, kNumThreadsPerBlock, topK * sizeof(int32_t),
+           stream>>>(logits.data_ptr<float>(), rowStarts.data_ptr<int>(),
+                     rowEnds.data_ptr<int>(), indices.data_ptr<int>(),
+                     static_cast<int>(stride0), static_cast<int>(stride1),
+                     static_cast<int>(topK), kSortingAlgorithmThreshold);
+  }
 }

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -179,15 +179,15 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
 
   // Optimized top-k per row operation
   ops.def(
-      "top_k_per_row(Tensor logits, Tensor rowStarts, Tensor rowEnds, "
+      "top_k_per_row_prefill(Tensor logits, Tensor rowStarts, Tensor rowEnds, "
       "Tensor! indices, int numRows, int stride0, "
-      "int stride1) -> ()");
-  ops.impl("top_k_per_row", torch::kCUDA, &top_k_per_row);
+      "int stride1, int topK) -> ()");
+  ops.impl("top_k_per_row_prefill", torch::kCUDA, &top_k_per_row_prefill);
 
   ops.def(
       "top_k_per_row_decode(Tensor logits, int next_n, "
-      "Tensor seq_lens, Tensor! indices, int numRows, "
-      "int stride0, int stride1) -> ()");
+      "Tensor seq_lens, Tensor! indices, "
+      "int numRows, int stride0, int stride1, int topK) -> ()");
   ops.impl("top_k_per_row_decode", torch::kCUDA, &top_k_per_row_decode);
 
   // Layernorm-quant

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -728,6 +728,18 @@ TORCH_LIBRARY_EXPAND(CONCAT(TORCH_EXTENSION_NAME, _cache_ops), cache_ops) {
       "dst_scale, Tensor block_table, Tensor cu_seq_lens) -> ()");
   cache_ops.impl("cp_gather_indexer_k_quant_cache", torch::kCUDA,
                  &cp_gather_indexer_k_quant_cache);
+
+  cache_ops.def(
+      "indexer_k_cache_fp16(Tensor k, Tensor! kv_cache, Tensor "
+      "slot_mapping) -> ()");
+  cache_ops.impl("indexer_k_cache_fp16", torch::kCUDA,
+                 &indexer_k_cache_fp16);
+
+  cache_ops.def(
+      "cp_gather_indexer_k_cache_fp16(Tensor kv_cache, Tensor! dst_k, "
+      "Tensor block_table, Tensor cu_seq_lens) -> ()");
+  cache_ops.impl("cp_gather_indexer_k_cache_fp16", torch::kCUDA,
+                 &cp_gather_indexer_k_cache_fp16);
 }
 
 TORCH_LIBRARY_EXPAND(CONCAT(TORCH_EXTENSION_NAME, _cuda_utils), cuda_utils) {

--- a/tests/kernels/test_top_k_per_row.py
+++ b/tests/kernels/test_top_k_per_row.py
@@ -9,23 +9,45 @@ from vllm.platforms import current_platform
 
 # Test parameters
 NUM_ROWS = [1, 32, 2050]
-TOP_K_VALUES = [2048]
-BATCH_SIZE = [1, 2, 4, 2048, 4096]
-NEXT_N = [1, 2, 4, 8]
+TOP_K_VALUES = [2048, 3000]
+BATCH_SIZE = [1, 2, 2048]
+NEXT_N = [1, 8]
+DATA_GENERATION = ["random", "10LSBits"]
 
 
 def create_random_logits(
     row_starts: torch.Tensor,
     row_ends: torch.Tensor,
-    vocab_size: int,
     dtype: torch.dtype,
     seed: int,
+    data_generation: str,
 ) -> torch.Tensor:
     """Create random logits tensor for testing."""
     torch.manual_seed(seed)
     np.random.seed(seed)
     # Generate logits with some structure to make testing more meaningful
-    logits = torch.randn(row_starts.shape[0], max(row_ends), dtype=dtype, device="cuda")
+    if data_generation == "random":
+        logits = torch.randn(
+            row_starts.shape[0], max(row_ends), dtype=dtype, device="cuda"
+        )
+    elif data_generation == "10LSBits":
+        top_22_bits_mask = 0xFFFFFC00
+        last_10_bits_mask = 0x000003FF
+        fixed_top_22_bits = 0x3F900000
+        # Generate random bits for the last 10 bits
+        random_bottom_bits = torch.randint(
+            0,
+            2**10,
+            (row_starts.shape[0], max(row_ends)),
+            dtype=torch.int32,
+            device="cuda",
+        )
+        # Combine: fixed top 22 bits with random last 10 bits
+        logits_bits = (fixed_top_22_bits & top_22_bits_mask) | (
+            random_bottom_bits & last_10_bits_mask
+        )
+        logits = logits_bits.view(dtype)
+
     for i, end in enumerate(row_ends):
         logits[i, end:] = float("-inf")
     return logits
@@ -113,13 +135,13 @@ def test_top_k_per_row(
     # Create test data
     vocab_size = 20000
     row_starts, row_ends = create_row_boundaries(num_rows, vocab_size)
-    logits = create_random_logits(row_starts, row_ends, vocab_size, torch.float32, 42)
+    logits = create_random_logits(row_starts, row_ends, torch.float32, 42, "random")
 
     # Create output tensors
     indices = torch.empty((num_rows, top_k), dtype=torch.int32, device="cuda")
 
     # Run CUDA implementation
-    torch.ops._C.top_k_per_row(
+    torch.ops._C.top_k_per_row_prefill(
         logits,
         row_starts,
         row_ends,
@@ -127,6 +149,7 @@ def test_top_k_per_row(
         num_rows,
         logits.stride(0),
         logits.stride(1),
+        top_k,
     )
 
     # Run reference implementation
@@ -139,27 +162,23 @@ def test_top_k_per_row(
     # Compare results
     assert compare_top_k_results(
         logits, indices, torch_indices, row_starts, row_ends, top_k
-    ), "CUDA top_k_per_row results don't match torch.topk"
+    ), "CUDA top_k_per_row_prefill results don't match torch.topk"
 
 
-@pytest.mark.parametrize("top_k", TOP_K_VALUES)
-@pytest.mark.parametrize("batch_size", BATCH_SIZE)
-@pytest.mark.parametrize("next_n", NEXT_N)
-@pytest.mark.skipif(not current_platform.is_cuda(), reason="This test requires CUDA")
-@torch.inference_mode()
-def test_top_k_per_row_decode(
+def _run_top_k_per_row_decode_test(
     top_k: int,
     batch_size: int,
     next_n: int,
+    vocab_size: int,
+    data_generation: str,
 ) -> None:
     """
-    Test top_k_per_row with seq_lens tensor.
+    Helper function to run top_k_per_row_decode test with given parameters.
     """
     torch.set_default_device("cuda:0")
 
     # Create test data
     num_rows = batch_size * next_n
-    vocab_size = 20000
     seq_lens = torch.randint(
         vocab_size, (batch_size,), dtype=torch.int32, device="cuda"
     )
@@ -167,7 +186,9 @@ def test_top_k_per_row_decode(
     row_indices = torch.arange(num_rows, device="cuda") // next_n
     next_n_offset = torch.arange(num_rows, device="cuda") % next_n
     row_ends = seq_lens[row_indices] - next_n + next_n_offset + 1
-    logits = create_random_logits(row_starts, row_ends, vocab_size, torch.float32, 42)
+    logits = create_random_logits(
+        row_starts, row_ends, torch.float32, 42, data_generation
+    )
 
     # Create output tensors
     indices = torch.empty((num_rows, top_k), dtype=torch.int32, device="cuda")
@@ -181,6 +202,7 @@ def test_top_k_per_row_decode(
         num_rows,
         logits.stride(0),
         logits.stride(1),
+        top_k,
     )
 
     torch.cuda.synchronize()
@@ -195,4 +217,41 @@ def test_top_k_per_row_decode(
     # Compare results
     assert compare_top_k_results(
         logits, indices, torch_indices, row_starts, row_ends, top_k
-    ), "CUDA top_k_per_row results don't match torch.topk"
+    ), "CUDA top_k_per_row_decode results don't match torch.topk"
+
+
+@pytest.mark.parametrize("top_k", TOP_K_VALUES)
+@pytest.mark.parametrize("batch_size", BATCH_SIZE)
+@pytest.mark.parametrize("next_n", NEXT_N)
+@pytest.mark.parametrize("data_generation", DATA_GENERATION)
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="This test requires CUDA")
+@torch.inference_mode()
+def test_top_k_per_row_decode(
+    top_k: int,
+    batch_size: int,
+    next_n: int,
+    data_generation: str,
+) -> None:
+    """
+    Test top_k_per_row with seq_lens tensor.
+    """
+    vocab_size = 20000
+    _run_top_k_per_row_decode_test(
+        top_k, batch_size, next_n, vocab_size, data_generation
+    )
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="This test requires CUDA")
+@torch.inference_mode()
+def test_top_k_per_row_decode_large_vocab_size() -> None:
+    """
+    Test top_k_per_row_decode with large vocabulary size.
+    """
+    top_k = 2048
+    batch_size = 2
+    next_n = 2
+    vocab_size = 300000
+    data_generation = "random"
+    _run_top_k_per_row_decode_test(
+        top_k, batch_size, next_n, vocab_size, data_generation
+    )

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -2296,6 +2296,26 @@ def cp_gather_indexer_k_quant_cache(
         kv_cache, dst_k, dst_scale, block_table, cu_seq_lens
     )
 
+def indexer_k_cache_fp16(
+    k: torch.Tensor,
+    kv_cache: torch.Tensor,
+    slot_mapping: torch.Tensor,
+) -> None:
+    torch.ops._C_cache_ops.indexer_k_cache_fp16(
+        k, kv_cache, slot_mapping
+    )
+
+
+def cp_gather_indexer_k_cache_fp16(
+    kv_cache: torch.Tensor,
+    dst_k: torch.Tensor,
+    block_table: torch.Tensor,
+    cu_seq_lens: torch.Tensor,
+) -> None:
+    torch.ops._C_cache_ops.cp_gather_indexer_k_cache_fp16(
+        kv_cache, dst_k, block_table, cu_seq_lens
+    )    
+
 
 def get_device_attribute(attribute: int, device: int) -> int:
     return torch.ops._C_cuda_utils.get_device_attribute(attribute, device)

--- a/vllm/attention/ops/rocm_aiter_mla_sparse.py
+++ b/vllm/attention/ops/rocm_aiter_mla_sparse.py
@@ -5,7 +5,6 @@ from functools import lru_cache
 
 import torch
 
-from vllm._aiter_ops import rocm_aiter_ops
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
@@ -94,7 +93,7 @@ def _fp16_mqa_logits_kernel(
             w_tile = tl.load(w_ptrs, mask=mask_q, other=0.0)
 
             # Compute Dot: [BLOCK_Q, D] @ [D, BLOCK_KV] -> [BLOCK_Q, BLOCK_KV]
-            score = tl.dot(q_tile, kv_block)
+            score = tl.dot(q_tile.to(tl.float32), kv_block.to(tl.float32))
             
             # Apply ReLU and Weight
             score = tl.maximum(score, 0.0)
@@ -121,6 +120,7 @@ def _fp16_mqa_logits_kernel(
         final_mask = mask_q[:, None] & mask_kv & in_window
         tl.store(logits_ptrs, acc, mask=final_mask)
 
+# First implementation attempt, not optimized, currently slower than torch reference
 def fp16_mqa_logits(
     Q,
     KV,
@@ -265,13 +265,13 @@ def fp16_mqa_logits_torch(
     q = q.float()
     
     seq_len_kv = kv.shape[0]
-    num_q, num_heads, head_dim = q.shape
+    num_q, num_heads, _ = q.shape
 
     # TODO: Make HEAD_CHUNK_SIZE as env variable if this non optimized vibe coded pytorch ops is still used in future build
     # Because HEAD_CHUNK_SIZE is also used in vllm/model_executor/models/deepseek_v2.py - sparse_attn_indexer_fake for the profile run to get correct memory usage
     # TUNE HEAD_CHUNK_SIZE according to AVAILABLE GPU VRAM 
-    # 1 heads * 2048 tokens * 2 (peak factor) * 32k context * 4 bytes ~= 0.5 GB memory peak / GPU.
-    HEAD_CHUNK_SIZE = 1 
+    # 4 heads * 512 tokens * 2 (peak factor) * 32k context * 4 bytes ~= 0.5 GB memory peak / GPU.
+    HEAD_CHUNK_SIZE = 4 
 
     # 1. Pre-allocate output
     final_logits = torch.full(
@@ -456,7 +456,7 @@ def fp16_paged_mqa_logits_torch(
         kv_slice = kv_cache[block_idxs]                 # [num_blocks, block_size, kv_heads, dim]
         kx = kv_slice.permute(2, 3, 0, 1).reshape(kv_slice.size(2), dim, -1)    # [kv_heads, dim, total_tokens]
         qx = q[i].transpose(0, 1)                       # q[i]: [next_n, heads, dim] -> [heads, next_n, dim]
-        s = torch.matmul(qx, kx).to(logits.dtype)       # [heads, next_n, dim] @ [1, dim, total_tokens] -> [heads, next_n, total_tokens] in fp32 here
+        s = torch.matmul(qx.float(), kx.float())       # [heads, next_n, dim] @ [1, dim, total_tokens] -> [heads, next_n, total_tokens] in fp32 here
 
         total_len = num_blocks * block_size
         k_offsets = torch.arange(0, total_len, device=q.device)
@@ -637,7 +637,7 @@ def _deepgemm_fp16_paged_mqa_logits_stage1(
         )
 
         # 5. Dot Product (FORCE FP32 ACCUMULATION)
-        o = tl.dot(q, k.T, out_dtype=tl.float32)
+        o = tl.dot(q.to(tl.float32), k.T.to(tl.float32), out_dtype=tl.float32)
         
         # 6. Activation (ReLU)
         # Matches reference: s = torch.relu(s)
@@ -666,6 +666,7 @@ def _deepgemm_fp16_paged_mqa_logits_stage1(
         )
         
 
+# First implementation attempt, not optimized, currently less stable (at 18k+ tokens context) but faster than torch reference
 def deepgemm_fp16_paged_mqa_logits_stage1(
     q: torch.Tensor,           # [Batch, NextN, Heads, Dim] (FP16)
     kv_cache: torch.Tensor,    # [NumBlocks, BlockSize, 1, Dim] (FP16)

--- a/vllm/attention/ops/rocm_aiter_mla_sparse.py
+++ b/vllm/attention/ops/rocm_aiter_mla_sparse.py
@@ -56,6 +56,94 @@ def fp8_mqa_logits_torch(
 
     return logits
 
+# Take from https://github.com/deepseek-ai/DeepGEMM/blob/main/tests/test_attention.py#L84
+def fp16_mqa_logits_torch(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    weights: torch.Tensor,
+    cu_seqlen_ks: torch.Tensor,
+    cu_seqlen_ke: torch.Tensor,
+) -> torch.Tensor:
+    """Compute MQA logits for a single sequence without KV paging.
+
+    Args:
+        q: Query tensor of shape [M, H, D]. fp16
+        kv: `kv` has shape [N, D] with dtype `torch.float16` 
+        weights: weights of shape [M, H], dtype `torch.float32`.
+        cu_seqlen_ks: Start indices (inclusive) for valid K per query position,
+            shape [M], dtype int32.
+        cu_seqlen_ke: End indices (exclusive) for valid K per query position,
+            shape [M], dtype int32.
+
+    Returns:
+        Logits tensor of shape [M, N], dtype `torch.float32`.
+    """
+    k = kv.float()
+    q = q.float()
+    
+    seq_len_kv = kv.shape[0]
+    num_q, num_heads, head_dim = q.shape
+
+    # TODO: Make HEAD_CHUNK_SIZE as env variable if this non optimized vibe coded pytorch ops is still used in future build
+    # Because HEAD_CHUNK_SIZE is also used in vllm/model_executor/models/deepseek_v2.py - sparse_attn_indexer_fake for the profile run to get correct memory usage
+    # TUNE HEAD_CHUNK_SIZE according to AVAILABLE GPU VRAM 
+    # 1 heads * 2048 tokens * 2 (peak factor) * 32k context * 4 bytes ~= 0.5 GB memory peak / GPU.
+    HEAD_CHUNK_SIZE = 1 
+
+    # 1. Pre-allocate output
+    final_logits = torch.full(
+        (num_q, seq_len_kv), 
+        float("-inf"), 
+        device=q.device, 
+        dtype=torch.float32
+    )
+
+    # 2. Prepare Mask (Broadcasting later)
+    mask_lo = (
+        torch.arange(0, seq_len_kv, device="cuda")[None, :] >= cu_seqlen_ks[:, None]
+    )
+    mask_hi = (
+        torch.arange(0, seq_len_kv, device="cuda")[None, :] < cu_seqlen_ke[:, None]
+    )
+    mask = mask_lo & mask_hi
+
+    # Accumulator
+    weighted_sum = torch.zeros((num_q, seq_len_kv), device=q.device, dtype=torch.float32)
+
+    # Permute for easier slicing: [H, M, D]
+    q_per_head = q.permute(1, 0, 2) 
+    weights_per_head = weights.t() # [H, M]
+    k_t = k.t() # [D, N]
+
+    # 3. Chunked Loop
+    for i in range(0, num_heads, HEAD_CHUNK_SIZE):
+        end = min(i + HEAD_CHUNK_SIZE, num_heads)
+        
+        # Slice the chunk: Shape [Chunk_Size, M, D]
+        q_chunk = q_per_head[i:end] 
+        w_chunk = weights_per_head[i:end].unsqueeze(-1) # [Chunk, M, 1]
+
+        # Matmul: [Chunk, M, D] @ [D, N] -> [Chunk, M, N]
+        # This is the heavy lifting.
+        score_chunk = torch.matmul(q_chunk, k_t)
+        
+        score_chunk = torch.relu(score_chunk)
+        
+        # Weighted sum: Sum over the chunk dimension (dim 0)
+        # [Chunk, M, N] * [Chunk, M, 1] -> [Chunk, M, N] -> Sum -> [M, N]
+        chunk_sum = (score_chunk * w_chunk).sum(dim=0)
+        
+        weighted_sum.add_(chunk_sum)
+        
+        # Explicit delete to encourage memory freeing before next chunk
+        del score_chunk
+        del chunk_sum
+
+    # 4. Final Masking
+    final_logits = torch.where(mask, weighted_sum, final_logits)
+
+    return final_logits
+
 
 def rocm_fp8_mqa_logits(
     q: torch.Tensor,
@@ -150,6 +238,50 @@ def fp8_paged_mqa_logits_torch(
                 i * next_n : (i + 1) * next_n,
                 block_rk * block_size : (block_rk + 1) * block_size,
             ] = torch.where(k_offsets[None, :] <= q_offsets[:, None], s, float("-inf"))
+    return logits
+
+# Taken from https://github.com/deepseek-ai/DeepGEMM/blob/main/tests/test_attention.py#L156
+def fp16_paged_mqa_logits_torch(
+    q: torch.Tensor,
+    kv_cache: torch.Tensor,
+    weights: torch.Tensor,
+    context_lens: torch.Tensor,
+    block_tables: torch.Tensor,
+    schedule_metadata: torch.Tensor,
+    max_model_len: int,
+):
+
+    batch_size, next_n, heads, dim = q.size()
+    num_block, block_size, _, dim = kv_cache.size()
+    logits = torch.full([batch_size * next_n, max_model_len], float('-inf'), device=q.device, dtype=torch.float32)
+    context_lens = context_lens.tolist()
+    
+    is_context_lens_2d = False # assumed to never be 2d
+   
+    for i in range(batch_size):
+        context_len = context_lens[i]
+        q_offsets = torch.full((next_n, ), context_len, device='cuda', dtype=torch.int32) if is_context_lens_2d \
+                    else torch.arange(context_len - next_n, context_len, device='cuda')
+        
+        weight_slice = (
+            weights[i * next_n : (i + 1) * next_n, :].transpose(0, 1).contiguous()
+        )
+        
+        num_blocks = (context_len + block_size - 1) // block_size
+        block_idxs = block_tables[i][:num_blocks]
+        kv_slice = kv_cache[block_idxs]                 # [num_blocks, block_size, kv_heads, dim]
+        kx = kv_slice.permute(2, 3, 0, 1).reshape(kv_slice.size(2), dim, -1)    # [kv_heads, dim, total_tokens]
+        qx = q[i].transpose(0, 1)                       # q[i]: [next_n, heads, dim] -> [heads, next_n, dim]
+        s = torch.matmul(qx, kx).to(logits.dtype)       # [heads, next_n, dim] @ [1, dim, total_tokens] -> [heads, next_n, total_tokens] in fp32 here
+
+        total_len = num_blocks * block_size
+        k_offsets = torch.arange(0, total_len, device=q.device)
+        mask = (k_offsets[None, :] < context_len) & (k_offsets[None, :] <= q_offsets[:, None])
+        s = torch.where(mask[None, :, :], s, float('-inf'))     # mask shape: [1, next_n, total_tokens]
+        s = torch.relu(s) * weight_slice[..., None]             # weight_slice: [heads, next_n] -> [heads, next_n, 1]
+        s = s.sum(dim=0)                                        # [next_n, total_tokens]
+        logits[i * next_n:(i + 1) * next_n, :total_len] = torch.where(k_offsets[None, :] <= q_offsets[:, None], s, float('-inf'))
+
     return logits
 
 

--- a/vllm/attention/ops/rocm_aiter_mla_sparse.py
+++ b/vllm/attention/ops/rocm_aiter_mla_sparse.py
@@ -8,9 +8,192 @@ import torch
 from vllm._aiter_ops import rocm_aiter_ops
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
+from vllm.triton_utils import tl, triton
+import vllm.envs as envs
 
 logger = init_logger(__name__)
 
+@triton.jit
+def _fp16_mqa_logits_kernel(
+    Q_ptr,              # [seq_len, H, D]
+    KV_ptr,             # [seq_len_kv, D]
+    weights_ptr,        # [seq_len, H]
+    cu_start_ptr,       # [seq_len]
+    cu_end_ptr,         # [seq_len]
+    logits_ptr,         # [seq_len, seq_len_kv]
+    seq_len,
+    seq_len_kv,
+    NUM_HEADS: tl.constexpr,
+    HEAD_SIZE: tl.constexpr,
+    # strides
+    stride_q_s: tl.int64,
+    stride_q_h: tl.constexpr,
+    stride_q_d: tl.constexpr,
+    stride_kv_s: tl.int64,
+    stride_kv_d: tl.constexpr,
+    stride_w_s: tl.int64,
+    stride_w_h: tl.constexpr,
+    stride_logits_s: tl.int64,
+    stride_logits_k: tl.int64,
+    # block sizes
+    BLOCK_Q: tl.constexpr,  # Process multiple queries at once
+    BLOCK_KV: tl.constexpr,
+):
+    # 1. Program ID handles a block of Queries now
+    pid = tl.program_id(0)
+    start_q = pid * BLOCK_Q
+    
+    # 2. Setup Query Offsets [BLOCK_Q]
+    offs_q = start_q + tl.arange(0, BLOCK_Q)
+    mask_q = offs_q < seq_len
+
+    # 3. Load Causal Mask boundaries for this block of Queries
+    # [BLOCK_Q] vector
+    qs_starts = tl.load(cu_start_ptr + offs_q, mask=mask_q, other=0)
+    qs_ends = tl.load(cu_end_ptr + offs_q, mask=mask_q, other=0)
+
+    # Optimization: Skip KV blocks that are completely outside the window for this Q block
+    # (Optional, but helps performance on diagonal)
+    # For simplicity, we process all and mask later, similar to original.
+
+    # 4. Loop over KV Cache in chunks
+    # We iterate 0..seq_len_kv
+    # For each KV chunk, we compute results for ALL heads and ALL queries in this block
+    for kv_start in range(0, seq_len_kv, BLOCK_KV):
+        offs_kv = kv_start + tl.arange(0, BLOCK_KV)
+        
+        # Load KV Transposed: [HEAD_SIZE, BLOCK_KV]
+        # We need (D, B) layout for dot product
+        d_inds = tl.arange(0, HEAD_SIZE)
+        kv_ptrs = (
+            KV_ptr 
+            + (offs_kv[None, :] * stride_kv_s) # col step
+            + (d_inds[:, None] * stride_kv_d)  # row step
+        )
+        # Mask for tail KV blocks
+        mask_kv = offs_kv[None, :] < seq_len_kv
+        kv_block = tl.load(kv_ptrs, mask=mask_kv, other=0.0)
+
+        # Accumulator for Logits: [BLOCK_Q, BLOCK_KV]
+        acc = tl.zeros([BLOCK_Q, BLOCK_KV], dtype=tl.float32)
+
+        # 5. Inner Loop: Iterate over Heads
+        # We process heads sequentially to save memory (Registers/LDS)
+        for h in range(NUM_HEADS):
+            # Load Q Tile for this Head: [BLOCK_Q, HEAD_SIZE]
+            q_ptrs = (
+                Q_ptr 
+                + (offs_q[:, None] * stride_q_s) 
+                + (h * stride_q_h) 
+                + (d_inds[None, :] * stride_q_d)
+            )
+            q_tile = tl.load(q_ptrs, mask=mask_q[:, None], other=0.0)
+
+            # Load Weights for this Head: [BLOCK_Q]
+            w_ptrs = weights_ptr + (offs_q * stride_w_s) + (h * stride_w_h)
+            w_tile = tl.load(w_ptrs, mask=mask_q, other=0.0)
+
+            # Compute Dot: [BLOCK_Q, D] @ [D, BLOCK_KV] -> [BLOCK_Q, BLOCK_KV]
+            score = tl.dot(q_tile, kv_block)
+            
+            # Apply ReLU and Weight
+            score = tl.maximum(score, 0.0)
+            score = score * w_tile[:, None] # broadcast weight along KV dim
+
+            # Accumulate
+            acc += score
+
+        # 6. Apply Causal Masking
+        # Check if KV indices are within [start, end) for each Q
+        # qs_starts is [BLOCK_Q], offs_kv is [BLOCK_KV]
+        # Broadcast comparisons
+        in_window = (offs_kv[None, :] >= qs_starts[:, None]) & \
+                    (offs_kv[None, :] < qs_ends[:, None])
+        
+        # 7. Store Logits
+        logits_ptrs = (
+            logits_ptr 
+            + (offs_q[:, None] * stride_logits_s) 
+            + (offs_kv[None, :] * stride_logits_k)
+        )
+        
+        # Mask out-of-bounds Q (tail) and out-of-bounds KV (tail) AND causal window
+        final_mask = mask_q[:, None] & mask_kv & in_window
+        tl.store(logits_ptrs, acc, mask=final_mask)
+
+def fp16_mqa_logits(
+    Q,
+    KV,
+    weights,
+    cu_starts,
+    cu_ends,
+):
+    """
+    This function computes the logits to be used by a topk function for sparse attention.
+
+    Q:           [seq_len, NUM_HEADS, HEAD_SIZE], dtype float16
+    KV:          [seq_len_kv, HEAD_SIZE], dtype float16
+    weights:     [seq_len, NUM_HEADS], dtype float32
+    cu_starts:   [seq_len], dtype int32, start indices
+    cu_ends:     [seq_len], dtype int32, end indices
+
+    Returns:
+    logits:      [seq_len, seq_len_kv], dtype float32 (must be initialized to -inf, because of causal masking)
+    """
+    seq_len, num_heads, head_size = Q.shape
+    seq_len_kv = KV.shape[0]
+    # TODO: Currently assuming num_heads and head_size is power of 2.
+    assert num_heads & (num_heads - 1) == 0, "num q. heads should be power of 2."
+    assert head_size & (head_size - 1) == 0, "head size should be power of 2."
+    # Initialize with -inf because of causal masking
+    logits = torch.full(
+        (seq_len, seq_len_kv),
+        fill_value=-float("inf"),
+        dtype=torch.float32,
+        device=Q.device,
+    )
+
+    stride_q_s, stride_q_h, stride_q_d = Q.stride()
+    stride_kv_s, stride_kv_d = KV.stride()
+    stride_w_s, stride_w_h = weights.stride()
+    stride_logits_s, stride_logits_k = logits.stride()
+
+    # BLOCK_Q=16: Processes 16 queries at once. Reduces memory loads by 16x.
+    # BLOCK_KV=64: Keeps LDS usage safe (~32KB total).
+    BLOCK_Q = 16
+    BLOCK_KV = 64
+
+    # Grid is now smaller because we handle BLOCK_Q items per program
+    grid = (triton.cdiv(seq_len, BLOCK_Q),)
+
+    _fp16_mqa_logits_kernel[grid](
+        Q_ptr=Q,
+        KV_ptr=KV,
+        weights_ptr=weights,
+        cu_start_ptr=cu_starts,
+        cu_end_ptr=cu_ends,
+        logits_ptr=logits,
+        seq_len=seq_len,
+        seq_len_kv=seq_len_kv,
+        NUM_HEADS=num_heads,
+        HEAD_SIZE=head_size,
+        stride_q_s=stride_q_s,
+        stride_q_h=stride_q_h,
+        stride_q_d=stride_q_d,
+        stride_kv_s=stride_kv_s,
+        stride_kv_d=stride_kv_d,
+        stride_w_s=stride_w_s,
+        stride_w_h=stride_w_h,
+        stride_logits_s=stride_logits_s,
+        stride_logits_k=stride_logits_k,
+        BLOCK_Q=BLOCK_Q,
+        BLOCK_KV=BLOCK_KV,
+        num_warps=4,
+        num_stages=1,     # Must be 1. Inner loop handles logic.
+        waves_per_eu=1,   # Conservative for safety on MI50 and best value possible for perf
+    )
+
+    return logits
 
 # Take from https://github.com/deepseek-ai/DeepGEMM/blob/main/tests/test_attention.py#L84
 def fp8_mqa_logits_torch(
@@ -145,9 +328,9 @@ def fp16_mqa_logits_torch(
     return final_logits
 
 
-def rocm_fp8_mqa_logits(
+def rocm_mqa_logits(
     q: torch.Tensor,
-    kv: tuple[torch.Tensor, torch.Tensor],
+    kv: tuple[torch.Tensor, torch.Tensor]|torch.Tensor,
     weights: torch.Tensor,
     cu_seqlen_ks: torch.Tensor,
     cu_seqlen_ke: torch.Tensor,
@@ -159,7 +342,7 @@ def rocm_fp8_mqa_logits(
             `torch.float8_e4m3fn` by caller.
         kv: Tuple `(k_fp8, k_scales)` where `k_fp8` has shape [N, D] with
             dtype `torch.float8_e4m3fn` and `k_scales` has shape [N] (or
-            [N, 1]) with dtype `torch.float32`.
+            [N, 1]) with dtype `torch.float32`. Or FP16 ([N, D])
         weights: weights of shape [M, H], dtype `torch.float32`.
         cu_seqlen_ks: Start indices (inclusive) for valid K per query position,
             shape [M], dtype int32.
@@ -176,14 +359,16 @@ def rocm_fp8_mqa_logits(
     def has_mqa_logits_module():
         return importlib.util.find_spec("aiter.ops.triton.fp8_mqa_logits") is not None
 
-    if rocm_aiter_ops.is_enabled() and has_mqa_logits_module():
+    if envs.VLLM_ROCM_USE_AITER and has_mqa_logits_module() and not envs.VLLM_ROCM_USE_AITER_MLA_SPARSE_FP16:
         from aiter.ops.triton.fp8_mqa_logits import fp8_mqa_logits
-
         kv, scale = kv
         return fp8_mqa_logits(q, kv, scale, weights, cu_seqlen_ks, cu_seqlen_ke)
-    else:
+    elif not envs.VLLM_ROCM_USE_AITER and not envs.VLLM_ROCM_USE_AITER_MLA_SPARSE_FP16:
         return fp8_mqa_logits_torch(q, kv, weights, cu_seqlen_ks, cu_seqlen_ke)
-
+    elif not envs.VLLM_ROCM_USE_AITER and envs.VLLM_ROCM_USE_AITER_MLA_SPARSE_FP16:
+        return fp16_mqa_logits_torch(q, kv, weights, cu_seqlen_ks, cu_seqlen_ke)
+    elif envs.VLLM_ROCM_USE_AITER and envs.VLLM_ROCM_USE_AITER_MLA_SPARSE_FP16:
+        return fp16_mqa_logits(q, kv, weights, cu_seqlen_ks, cu_seqlen_ke)
 
 # Taken from https://github.com/deepseek-ai/DeepGEMM/blob/main/tests/test_attention.py#L156
 def fp8_paged_mqa_logits_torch(
@@ -247,7 +432,6 @@ def fp16_paged_mqa_logits_torch(
     weights: torch.Tensor,
     context_lens: torch.Tensor,
     block_tables: torch.Tensor,
-    schedule_metadata: torch.Tensor,
     max_model_len: int,
 ):
 
@@ -285,9 +469,9 @@ def fp16_paged_mqa_logits_torch(
     return logits
 
 
-def rocm_fp8_paged_mqa_logits(
-    q_fp8: torch.Tensor,
-    kv_cache_fp8: torch.Tensor,
+def rocm_paged_mqa_logits(
+    q: torch.Tensor,
+    kv_cache: torch.Tensor,
     weights: torch.Tensor,
     context_lens: torch.Tensor,
     block_tables: torch.Tensor,
@@ -297,11 +481,11 @@ def rocm_fp8_paged_mqa_logits(
     """Compute FP8 MQA logits using paged KV-cache.
 
     Args:
-        q_fp8: Query tensor of shape [B, next_n, H, D]. Casted to
-            `torch.float8_e4m3fn` by caller.
-        kv_cache_fp8: Paged KV-cache in packed FP8+scale layout with shape
+        q: Query tensor of shape [B, next_n, H, D]. Casted to
+            `torch.float8_e4m3fn` by caller, or native fp16
+        kv_cache: Paged KV-cache in packed FP8+scale layout with shape
             [num_blocks, block_size, 1, D+4], dtype `torch.uint8`. The last
-            4 bytes per (block,pos) store the `float` dequant scale.
+            4 bytes per (block,pos) store the `float` dequant scale. Or FP16 : [num_blocks, block_size, 1, D]
         weights: Tensor of shape [B * next_n, H], dtype `torch.float32`.
         context_lens: Tensor of shape [B], dtype int32; effective context length
             for each batch element.
@@ -315,11 +499,11 @@ def rocm_fp8_paged_mqa_logits(
         Logits tensor of shape [B * next_n, max_model_len], dtype
         `torch.float32`.
     """
-
-    if rocm_aiter_ops.is_enabled():
+    batch_size, next_n, heads, _ = q.shape
+    
+    if envs.VLLM_ROCM_USE_AITER and not envs.VLLM_ROCM_USE_AITER_MLA_SPARSE_FP16:
         from aiter.ops.triton.pa_mqa_logits import deepgemm_fp8_paged_mqa_logits_stage1
 
-        batch_size, next_n, heads, _ = q_fp8.shape
         out_qk = torch.full(
             (heads, batch_size * next_n, max_model_len),
             float("-inf"),
@@ -327,8 +511,8 @@ def rocm_fp8_paged_mqa_logits(
             dtype=torch.float32,
         )
         deepgemm_fp8_paged_mqa_logits_stage1(
-            q_fp8,
-            kv_cache_fp8,
+            q,
+            kv_cache,
             weights,
             out_qk,
             context_lens,
@@ -336,7 +520,218 @@ def rocm_fp8_paged_mqa_logits(
             max_model_len,
         )
         return out_qk.sum(dim=0)
-    else:
-        return fp8_paged_mqa_logits_torch(
-            q_fp8, kv_cache_fp8, weights, context_lens, block_tables, max_model_len
+    elif not envs.VLLM_ROCM_USE_AITER and not envs.VLLM_ROCM_USE_AITER_MLA_SPARSE_FP16:
+        return fp8_paged_mqa_logits_torch(q, kv_cache, weights, context_lens, block_tables, max_model_len)
+    elif not envs.VLLM_ROCM_USE_AITER and envs.VLLM_ROCM_USE_AITER_MLA_SPARSE_FP16:
+        return fp16_paged_mqa_logits_torch(q, kv_cache, weights, context_lens, block_tables, max_model_len)
+    elif envs.VLLM_ROCM_USE_AITER and envs.VLLM_ROCM_USE_AITER_MLA_SPARSE_FP16:
+        out_qk = torch.full(
+            (heads, batch_size * next_n, max_model_len),
+            float("-inf"),
+            device="cuda",
+            dtype=torch.float32,
         )
+        deepgemm_fp16_paged_mqa_logits_stage1(
+            q,
+            kv_cache,
+            weights,
+            out_qk,
+            context_lens,
+            block_tables,
+            max_model_len,
+        )
+        return out_qk.sum(dim=0)
+
+@triton.jit
+def _deepgemm_fp16_paged_mqa_logits_stage1(
+    batch_size,
+    next_n,
+    heads_num,
+    Q_buffer,           # FP16
+    stride_q_batch,
+    stride_q_next_n,
+    stride_q_heads,
+    KV_buffer,          # FP16 [NumBlocks, BlockSize, Heads, Dim]
+    stride_k_blk,       # Stride(0): Jump to next physical block (numel per block)
+    stride_k_tok,       # Stride(1): Jump to next token inside block (usually Heads*Dim)
+    context_len_ptr,
+    block_table,        # [Batch, MaxNumBlocks] - Note: This is now a BLOCK table, not token indices
+    weights,            # [Batch*NextN, Heads] FP32
+    stride_w_batch,
+    Out_buffer,
+    stride_out_heads,
+    stride_out_batch,
+    max_model_len,
+    max_num_blocks,     # Changed from max_blk_len (tokens) to max_num_blocks
+    ChunkQ: tl.constexpr,
+    ChunkK: tl.constexpr, # Must match BlockSize (e.g., 64)
+    HiddenDim: tl.constexpr,
+    SplitKV: tl.constexpr = 1,
+):
+    pid = tl.program_id(0)
+    num_block_q_head = tl.cdiv(heads_num, ChunkQ)
+
+    pid_q_head, remain_pid = pid % num_block_q_head, pid // num_block_q_head
+    pid_next_n, remain_pid = remain_pid % next_n, remain_pid // next_n
+    pid_batch, pid_split_kv = remain_pid % batch_size, remain_pid // batch_size
+
+    context_length = tl.load(context_len_ptr + pid_batch)
+
+    # Grid logic
+    context_chunk_num = tl.cdiv(context_length, ChunkK)
+    split_context_chunk_num = tl.cdiv(context_chunk_num, SplitKV)
+    split_context_start = (pid_split_kv * split_context_chunk_num) * ChunkK
+        
+    # Cap the length to the assigned split
+    split_context_length = min(
+        context_length - split_context_start, split_context_chunk_num * ChunkK
+    )
+
+    # 1. Load Q (FP16)
+    q = tl.load(
+        Q_buffer
+        + pid_batch * stride_q_batch
+        + pid_next_n * stride_q_next_n
+        + ((pid_q_head * ChunkQ + tl.arange(0, ChunkQ)) * stride_q_heads)[:, None]
+        + tl.arange(0, HiddenDim)[None, :],
+    )
+
+    # 2. Load Weights (FP32)
+    # Based on reference: weight_slice = weights[i * next_n:(i + 1) * next_n, ...]
+    # These act as gating/scaling factors after ReLU.
+    scale_weight = tl.load(
+        weights
+        + (pid_batch * next_n + pid_next_n) * stride_w_batch
+        + pid_q_head * ChunkQ
+        + tl.arange(0, ChunkQ)
+    )
+
+    # Loop over KV blocks
+    # CRITICAL CHANGE: We iterate aligned to ChunkK (64)
+    # We assume ChunkK == BlockSize for this implementation
+    for context_idx in range(
+        split_context_start, split_context_start + split_context_length, ChunkK
+    ):
+        # 3. Paged Attention Indexing
+        # a. Calculate which logical block we are in
+        current_logical_block = context_idx // ChunkK
+        
+        # b. Load the Physical Block ID from the Block Table
+        #    block_table shape: [Batch, MaxNumBlocks]
+        physical_block_id = tl.load(
+            block_table + pid_batch * max_num_blocks + current_logical_block
+        )
+
+        mask_kv = context_idx + tl.arange(0, ChunkK) < context_length
+
+        # 4. Load K (FP16)
+        #    Pointer = Base of Physical Block + Offset for Token inside Block
+        #    KV_buffer shape is [NumPhysicalBlocks, BlockSize, 1, Dim]
+        k = tl.load(
+            KV_buffer
+            + physical_block_id * stride_k_blk      # Jump to the correct physical block
+            + tl.arange(0, ChunkK)[:, None] * stride_k_tok # Iterate tokens 0..63 inside that block
+            + tl.arange(0, HiddenDim)[None, :],     # Iterate dim
+            mask=mask_kv[:, None],
+            other=0.0,
+        )
+
+        # 5. Dot Product (FORCE FP32 ACCUMULATION)
+        o = tl.dot(q, k.T, out_dtype=tl.float32)
+        
+        # 6. Activation (ReLU)
+        # Matches reference: s = torch.relu(s)
+        o = tl.maximum(o, 0.0)
+
+        # 7. Apply Weights (Gating)
+        # Matches reference: s = s * weight_slice
+        # scale_weight shape is [ChunkQ], o is [ChunkQ, ChunkK]
+        # We broadcast scale_weight to apply per-head scaling
+        o = o * scale_weight[None, :].T
+
+        # 8. Masking (Causal/Padding)
+        mask = (
+            context_idx + tl.arange(0, ChunkK) <= context_length - next_n + pid_next_n
+        )
+        o = tl.where(mask[None, :], o, float("-inf"))
+
+        # Store Output
+        tl.store(
+            Out_buffer
+            + (pid_batch * next_n + pid_next_n) * stride_out_batch
+            + (pid_q_head * ChunkQ + tl.arange(0, ChunkQ)[:, None, None])
+            * stride_out_heads
+            + (context_idx + tl.arange(0, ChunkK)[None, None, :]),
+            o[:, None, :],
+        )
+        
+
+def deepgemm_fp16_paged_mqa_logits_stage1(
+    q: torch.Tensor,           # [Batch, NextN, Heads, Dim] (FP16)
+    kv_cache: torch.Tensor,    # [NumBlocks, BlockSize, 1, Dim] (FP16)
+    weights: torch.Tensor,     # [Batch * NextN, Heads] (FP32)
+    out_qk: torch.Tensor,      # Output Logits (FP32)
+    context_lens: torch.Tensor,
+    block_tables: torch.Tensor, # [Batch, MaxNumBlocks] (Not per-token as blockSize !=1)
+    max_model_len: int,
+    # MI50 TUNED DEFAULTS:
+    ChunkQ: int = 16,           # Smaller tiles = More thread blocks = Higher Occupancy on MI50's 60 CUs.
+    ChunkK: int = 64,           # Must match BlockSize, 64 has slightly better performance than 32 (with ChunkQ=32).
+    TotalCuCount: int = 60,     # MI50 has 60 CU
+    WavePerEU: int = 1,         # Stability
+    num_warps: int = 4,   # Sweet spot for register usage on gfx906.
+    num_stages: int = 1,  # Essential for stability (avoids LDS crashes)
+):
+    # Validation
+    assert q.dtype == torch.float16
+    assert kv_cache.dtype == torch.float16
+    
+    # Check Block Size matches ChunkK
+    block_size = kv_cache.size(1) 
+    assert block_size == ChunkK, f"Kernel requires BlockSize ({block_size}) == ChunkK ({ChunkK})"
+    
+    batch_size, next_n, heads, hidden_dim = q.size()
+    _, max_num_blocks = block_tables.size()
+
+    # Calculate strides for the KV Cache
+    # KV Cache: [NumBlocks, BlockSize, 1, Dim]
+    stride_k_blk = kv_cache.stride(0)  # Steps to jump 1 physical block
+    stride_k_tok = kv_cache.stride(1)  # Steps to jump 1 token inside a block
+
+    TileQCount = batch_size * next_n * (heads // ChunkQ)
+    SplitKV = (max(1, TotalCuCount // TileQCount) + 4) // 5 * 5 * WavePerEU
+
+    config = {
+        "ChunkQ": ChunkQ,
+        "ChunkK": ChunkK,
+        "HiddenDim": hidden_dim,
+        "SplitKV": SplitKV,
+    }
+    
+    grid = (batch_size * next_n * (heads // config["ChunkQ"] * SplitKV),)
+    
+    _deepgemm_fp16_paged_mqa_logits_stage1[grid](
+        batch_size,
+        next_n,
+        heads,
+        q,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        kv_cache,
+        stride_k_blk,  # Stride per block
+        stride_k_tok,  # Stride per token
+        context_lens,
+        block_tables,  # Block Table
+        weights,
+        weights.stride(0),
+        out_qk,
+        out_qk.stride(0),
+        out_qk.stride(1),
+        max_model_len,
+        max_num_blocks, # Max Blocks, not tokens
+        num_warps=num_warps,
+        num_stages=num_stages,
+        **config,
+    )
+    

--- a/vllm/attention/ops/triton_decode_attention.py
+++ b/vllm/attention/ops/triton_decode_attention.py
@@ -29,6 +29,7 @@ Memory-efficient attention for decoding.
 It supports page size >= 1.
 """
 
+import functools
 import logging
 
 from packaging import version
@@ -39,6 +40,11 @@ from vllm.triton_utils import tl, triton
 is_hip_ = current_platform.is_rocm()
 
 logger = logging.getLogger(__name__)
+
+@functools.cache
+def is_rocm_gfx906():
+    return current_platform.is_rocm() and triton.runtime.driver.active.get_current_target().arch in ["gfx906"] 
+
 
 # Only print the following warnings when triton version < 3.2.0.
 # The issue won't affect performance or accuracy.
@@ -239,7 +245,7 @@ def _decode_att_m_fwd(
         PAGE_SIZE=page_size,
         logit_cap=logit_cap,
         num_warps=num_warps,
-        num_stages=2,
+        num_stages=2 if not is_rocm_gfx906 else 1,
         Lk=Lk,
         Lv=Lv,
     )
@@ -452,10 +458,12 @@ def _decode_grouped_att_m_fwd(
 
     extra_kargs = {}
     num_stages = 2
-    if is_hip_:
+    if is_hip_ and not is_rocm_gfx906:
         # https://rocm.docs.amd.com/en/latest/how-to/rocm-for-ai/inference-optimization/workload.html#mi300x-triton-kernel-performance-optimization
         # https://github.com/triton-lang/triton/blob/main/third_party/amd/backend/compiler.py
         extra_kargs = {"waves_per_eu": 1, "matrix_instr_nonkdim": 16, "kpack": 2}
+        num_stages = 1
+    if is_rocm_gfx906:
         num_stages = 1
 
     _fwd_grouped_kernel_stage1[grid](
@@ -573,7 +581,7 @@ def _decode_softmax_reducev_fwd(
     NUM_KV_SPLITS = num_kv_splits
 
     extra_kargs = {}
-    if is_hip_:
+    if is_hip_ and not is_rocm_gfx906:
         # https://rocm.docs.amd.com/en/docs-6.2.0/how-to/llm-fine-tuning-optimization/optimizing-triton-kernel.html
         # https://github.com/triton-lang/triton/blob/main/third_party/amd/backend/compiler.py
         extra_kargs = {"waves_per_eu": 4, "matrix_instr_nonkdim": 16, "kpack": 2}
@@ -594,7 +602,7 @@ def _decode_softmax_reducev_fwd(
         BLOCK_DV=BLOCK_DV,
         Lv=Lv,
         num_warps=4,
-        num_stages=2,
+        num_stages=2 if not is_rocm_gfx906 else 1,
         **extra_kargs,
     )
 

--- a/vllm/attention/ops/triton_flash_attention.py
+++ b/vllm/attention/ops/triton_flash_attention.py
@@ -1,0 +1,1408 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Fused Attention
+===============
+
+This is a Triton implementation of the Flash Attention v2 algorithm
+See https://tridao.me/publications/flash2/flash2.pdf
+
+Credits:
+AMD Triton kernels team
+OpenAI kernel team
+
+Currently only the forward kernel is supported, and contains these features:
+
+1) Fwd with causal masking
+2) Arbitrary Q and KV sequence lengths
+3) Arbitrary head sizes
+4) Multi and grouped query attention
+5) Variable sequence lengths
+6) ALiBi and matrix bias
+7) FP8 support
+
+"""
+
+from typing import Optional
+
+import torch
+
+from vllm import _custom_ops as ops
+from vllm.platforms import current_platform
+from vllm.triton_utils import tl, triton
+
+SUPPORTED_LAYOUTS = ['thd', 'bhsd', 'bshd']
+
+default_eight_bit_dtype_triton = tl.float8e4b8
+default_eight_bit_dtype_torch = current_platform.fp8_dtype()
+default_float8_info = torch.finfo(default_eight_bit_dtype_torch)
+
+FP8_MIN = triton.language.constexpr(default_float8_info.min)
+
+# According to https://github.com/vllm-project/vllm/blob/main
+#              /csrc/quantization/utils.cuh#L31,
+# need to make the max for the uz datatype be 224.0 for accuracy reasons.
+FP8_MAX = triton.language.constexpr(
+    default_float8_info.max if default_eight_bit_dtype_torch !=
+    torch.float8_e4m3fnuz else 224.0)
+
+
+class MetaData:
+    cu_seqlens_q = None
+    cu_seqlens_k = None
+    max_seqlens_q = 0
+    max_seqlens_k = 0
+    bias = None
+    alibi_slopes = None
+    causal = False
+    num_contexts = 0
+    varlen = False
+    eight_bit = False
+    layout = None
+    return_encoded_softmax = False
+    eight_bit_dtype_triton = default_eight_bit_dtype_triton
+    eight_bit_dtype_torch = default_eight_bit_dtype_torch
+    output_dtype = None
+
+    # Note about layouts:
+    #
+    # thd - [num_tokens, num_heads, head_size]
+    # bshd - [batch_size, seq_len, num_heads, head_size]
+    # bhsd - [batch_size, num_heads, seq_len, head_size]
+    #
+    # This is for each tensor, all tensors must have same layout.
+    # Q can have num_heads and seq_len differ from  from K and V,
+    # however K and V must agree on this.
+    #
+    # Notes about varlen and bias:
+    # Only one or the other is implemented, meaning can't combine
+    # both varlen and bias right now.
+    #
+    # Note about quantization:
+    # Only 8-bit quantization supported (for now) and specifically fp8.
+    # Scales must be tensors.
+    # o_scale: This is 'output scaling', but comes from parameter called
+    # 'input_scale', this is applied to the output from the kernel.
+    # o_scale should be None if none of the other quantization parameters
+    # are used.
+    #
+    # NOTE: Object is in a tentatively good state after initialized, however,
+    # to verify, call check_args(q,k,v,o) where o is the output tensor.
+    def __init__(
+        self,
+        sm_scale=1.0,
+        layout=None,  # layout can be 'bshd', 'bhsd', or 'thd'
+        output_dtype=None,
+        max_seqlens_q=0,
+        max_seqlens_k=0,
+        # varlen params
+        cu_seqlens_q=None,  # only 'thd' layout supported for varlen 
+        cu_seqlens_k=None,
+        # quant params
+        q_descale=None,
+        k_descale=None,
+        v_descale=None,
+        p_scale=None,
+        o_scale=None,
+        # bias params
+        bias=None,  # varlen not implemented for bias
+        seqlen_q=None,
+        seqlen_k=None,
+        # alibi params
+        alibi_slopes=None,
+        alibi_batch=None,
+        alibi_nheads=None,
+        # causal
+        causal=None,
+    ):
+        self.sm_scale = sm_scale
+        self.output_dtype = output_dtype
+        self.max_seqlens_q = max_seqlens_q
+        self.max_seqlens_k = max_seqlens_k
+        self.layout = layout
+        if cu_seqlens_q is not None or cu_seqlens_k is not None:
+            assert cu_seqlens_q is not None and cu_seqlens_k is not None
+            assert layout is None or layout not in [
+                'bshd', 'bhsd'
+            ], "Varlen only implemented for thd layout"
+            self.set_varlen_params(cu_seqlens_q, cu_seqlens_k)
+        quant_params = [q_descale, k_descale, v_descale, p_scale, o_scale]
+        if any(x is not None for x in quant_params):
+            p_descale = 1.0 / p_scale if p_scale is not None else None
+            self.set_eight_bit_params(q_descale, k_descale, v_descale, p_scale,
+                                      p_descale, o_scale)
+        if bias is not None:
+            self.need_bias(bias, seqlen_q, seqlen_k)
+        if alibi_slopes is not None:
+            self.need_alibi(alibi_slopes, alibi_batch, alibi_nheads)
+        if causal is not None and causal:
+            self.need_causal()
+
+    def set_varlen_params(self, cu_seqlens_q, cu_seqlens_k):
+        self.varlen = True
+        self.layout = 'thd'
+        self.cu_seqlens_q = cu_seqlens_q
+        self.cu_seqlens_k = cu_seqlens_k
+        # Without "varlen", there should still be one sequence.
+        assert len(cu_seqlens_q) >= 2
+        assert len(cu_seqlens_q) == len(cu_seqlens_k)
+        self.num_contexts = len(cu_seqlens_q) - 1
+        for i in range(0, self.num_contexts):
+            self.max_seqlens_q = max(
+                cu_seqlens_q[i + 1].item() - cu_seqlens_q[i].item(),
+                self.max_seqlens_q)
+            self.max_seqlens_k = max(
+                cu_seqlens_k[i + 1].item() - cu_seqlens_k[i].item(),
+                self.max_seqlens_k)
+
+    def set_eight_bit_params(self, q_descale, k_descale, v_descale, p_scale,
+                             p_descale, o_scale):
+        self.eight_bit = True
+        self.q_descale = q_descale
+        self.k_descale = k_descale
+        self.v_descale = v_descale
+        self.p_scale = p_scale
+        self.p_descale = p_descale
+        self.o_scale = o_scale
+        self.use_p_scale = (p_scale is not None) and (
+            p_descale is not None) and (v_descale is not None)
+        self.eight_bit_kv = ((q_descale is None) and (k_descale is not None)
+                             and (v_descale is not None))
+        self.eight_bit_dtype_torch = default_eight_bit_dtype_torch
+
+    def need_bias(self, bias, seqlen_q, seqlen_k):
+        assert bias is not None
+        assert bias.is_cuda
+        assert bias.dim() == 4
+        assert bias.shape[0] == 1
+        assert bias.shape[2:] == (seqlen_q, seqlen_k)
+        self.bias = bias
+
+    def need_alibi(self, alibi_slopes, batch, nheads):
+        assert alibi_slopes.is_cuda
+        assert alibi_slopes.dim() == 2
+        assert alibi_slopes.shape[0] == batch
+        assert alibi_slopes.shape[1] == nheads
+        self.alibi_slopes = alibi_slopes
+
+    def need_causal(self):
+        self.causal = True
+
+    def check_args(self, q, k, v, o):
+        assert q.dim() == k.dim() and q.dim() == v.dim()
+
+        batch, nheads_q, nheads_k, head_size = get_shape_from_layout(
+            q, k, self)
+        if self.varlen:
+            assert q.dim() == 3
+            assert self.cu_seqlens_q is not None
+            assert self.cu_seqlens_k is not None
+            assert len(self.cu_seqlens_q) == len(self.cu_seqlens_k)
+            # TODO: Remove once bias is supported with varlen
+            assert self.bias is None
+            assert not self.return_encoded_softmax
+        else:
+            assert q.dim() == 4
+            assert self.max_seqlens_q > 0 and self.max_seqlens_k > 0
+            assert self.cu_seqlens_q is None and self.cu_seqlens_k is None
+        assert k.shape == v.shape
+        assert q.shape[-1] == k.shape[-1] and q.shape[-1] == v.shape[-1]
+        # TODO: Change assert if we support qkl f8 and v f16
+        if self.eight_bit:
+            if self.eight_bit_kv:
+                assert (v.dtype == k.dtype
+                        and k.dtype == self.eight_bit_dtype_torch)
+                assert q.dtype != k.dtype
+                assert (self.v_descale is not None) and (self.k_descale
+                                                         is not None)
+            else:
+                assert (q.dtype == k.dtype and q.dtype == v.dtype
+                        and q.dtype == self.eight_bit_dtype_torch)
+                assert (self.q_descale
+                        is not None) and (self.k_descale
+                                          is not None) and (self.v_descale
+                                                            is not None)
+                if self.use_p_scale:
+                    assert (self.p_scale is not None) and (self.p_descale
+                                                           is not None)
+        else:
+            assert (q.dtype == k.dtype) and (q.dtype == v.dtype)
+        assert head_size <= 256
+        assert o.shape == q.shape
+        assert (nheads_q % nheads_k) == 0
+        assert self.layout is not None
+        assert self.layout == 'thd' or not self.varlen
+
+
+@triton.jit
+def cdiv_fn(x, y):
+    return (x + y - 1) // y
+
+
+@triton.jit
+def max_fn(x, y):
+    return tl.math.max(x, y)
+
+
+# Convenience function to load with optional boundary checks.
+# "First" is the major dim, "second" is the minor dim.
+@triton.jit
+def masked_load(ptrs, offset_first, offset_second, boundary_first,
+                boundary_second):
+    if offset_first is not None and offset_second is not None:
+        mask = (offset_first[:, None] < boundary_first) & \
+               (offset_second[None, :] < boundary_second)
+        tensor = tl.load(ptrs, mask=mask, other=0.0)
+    elif offset_first is not None:
+        mask = offset_first[:, None] < boundary_first
+        tensor = tl.load(ptrs, mask=mask, other=0.0)
+    elif offset_second is not None:
+        mask = offset_second[None, :] < boundary_second
+        tensor = tl.load(ptrs, mask=mask, other=0.0)
+    else:
+        tensor = tl.load(ptrs)
+    return tensor
+
+
+@triton.jit
+def compute_alibi_block(alibi_slope,
+                        seqlen_q,
+                        seqlen_k,
+                        offs_m,
+                        offs_n,
+                        transpose=False):
+    # when seqlen_k and seqlen_q are different we want the diagonal to stick to
+    # the bottom right of the attention matrix
+    # for casual mask we want something like this where (1 is kept and 0 is
+    # masked)
+    # seqlen_q = 2 and seqlen_k = 5
+    #   1 1 1 1 0
+    #   1 1 1 1 1
+    # seqlen_q = 5 and seqlen_k = 2
+    #        0 0
+    #        0 0
+    #        0 0
+    #        1 0
+    #        1 1
+    # for alibi the diagonal is 0 indicating no penalty for attending to that
+    # spot and increasing penalty for attending further from the diagonal
+    # e.g. alibi_slope = 1, seqlen_q = 2, seqlen_k = 5,
+    # offs_m = [0, 1, 2, 3], offs_n = [0, 1, 2, 3, 4], transpose = False
+    # 1. offs_m[:,None] = [[0],
+    #                       [1],
+    # 2. offs_m[:,None] + seqlen_k = [[5],
+    #                                  [6],
+    # 3. offs_m[:,None] + seqlen_k - seqlen_q = [[3],
+    #                                             [4],
+    # 4. offs_m[:,None] + seqlen_k - seqlen_q - offs_n[None,:] =
+    # [[3], - [[0, 1, 2, 3, 4]] =  [[ 3, 2, 1, 0,-1], [4], [ 4, 3, 2, 1, 0]]
+    # 5. -1 * alibi_slope * tl.abs(relative_pos_block) = [[ -3, -2, -1, 0,-1],
+    #                                                    [ -4, -3, -2, -1, 0]],
+    relative_pos_block = (offs_m[:, None] + seqlen_k - seqlen_q -
+                          offs_n[None, :])
+    alibi_block = -1 * alibi_slope * tl.abs(relative_pos_block)
+    if transpose:
+        return alibi_block.T
+    else:
+        return alibi_block
+
+
+def compute_alibi_tensor(alibi_slopes, seqlen_q, seqlen_k):
+    q_idx = torch.arange(seqlen_q, dtype=torch.int32,
+                         device="cuda").unsqueeze(-1)  # (N_CTX_Q, 1)
+    k_idx = torch.arange(seqlen_k, dtype=torch.int32,
+                         device="cuda").unsqueeze(0)  # (1, N_CTX_K)
+    relative_pos = torch.abs(q_idx + seqlen_k - seqlen_q -
+                             k_idx)  # (N_CTX_Q, N_CTX_K)
+    return -1 * alibi_slopes.unsqueeze(-1).unsqueeze(
+        -1) * relative_pos  # (Z, H, N_CTX_Q, N_CTX_K)
+
+
+@triton.jit
+def quant_fp8(x, scale):
+    x *= scale
+    x = tl.clamp(x, FP8_MIN, FP8_MAX)
+    return x
+
+
+@triton.jit
+def _attn_fwd_inner(
+    acc,
+    l_i,
+    m_i,
+    q,
+    k_ptrs,
+    v_ptrs,
+    bias_ptrs,
+    stride_kn,
+    stride_vk,
+    stride_bn,
+    start_m,
+    actual_seqlen_k,
+    actual_seqlen_q,
+    philox_seed,
+    batch_philox_offset,
+    encoded_sm_ptrs,
+    block_min,
+    block_max,
+    offs_n_causal,
+    masked_blocks,
+    n_extra_tokens,
+    alibi_slope,
+    q_descale,
+    k_descale,
+    v_descale,
+    p_scale,
+    IS_CAUSAL: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_DMODEL: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    OFFS_M: tl.constexpr,
+    OFFS_N: tl.constexpr,
+    SHOULD_PRE_LOAD_V: tl.constexpr,
+    SHOULD_MASK_STEPS: tl.constexpr,
+    SHOULD_RETURN_ENCODED_SOFTMAX: tl.constexpr,
+    USE_PADDED_HEAD: tl.constexpr,
+    IS_ACTUAL_BLOCK_DMODEL: tl.constexpr,
+    QK_SCALE: tl.constexpr,
+    IS_EIGHT_BIT_GEMM: tl.constexpr,
+    USE_P_SCALE: tl.constexpr,
+    IS_EIGHT_BIT_KV: tl.constexpr,
+    QUANT_DTYPE: tl.constexpr = default_eight_bit_dtype_triton,
+):
+
+    # loop over k, v, and update accumulator
+    for start_n in range(block_min, block_max, BLOCK_N):
+        # For padded blocks, we will overrun the tensor size if
+        # we load all BLOCK_N. For others, the blocks are all within range.
+        k_offs_n = start_n + tl.arange(0,
+                                       BLOCK_N) if SHOULD_MASK_STEPS else None
+        k_offs_k = None if not USE_PADDED_HEAD else tl.arange(0, BLOCK_DMODEL)
+        k = masked_load(k_ptrs, k_offs_k, k_offs_n, IS_ACTUAL_BLOCK_DMODEL,
+                        actual_seqlen_k)
+        if SHOULD_PRE_LOAD_V:
+            # We can use the same offsets as k, just with dims transposed.
+            v = masked_load(v_ptrs, k_offs_n, k_offs_k, actual_seqlen_k,
+                            IS_ACTUAL_BLOCK_DMODEL)
+        qk = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32)
+        # We start from end of seqlen_k so only the first iteration would need
+        # to be checked for padding if it is not a multiple of block_n
+        # TODO: This can be optimized to only be true for the padded block.
+        if SHOULD_MASK_STEPS:  # noqa: SIM102
+            # If this is the last block / iteration, we want to
+            # mask if the sequence length is not a multiple of block size
+            # a solution is to always do BLOCK_M // BLOCK_N + 1 steps if not
+            # is_modulo_mn. last step might get wasted but that is okay.
+            # check if this masking works for that case.
+            if (start_n + BLOCK_N == block_max) and (n_extra_tokens != 0):
+                boundary_m = tl.full([BLOCK_M],
+                                     actual_seqlen_k,
+                                     dtype=tl.int32)
+                size_n = start_n + OFFS_N[None, :]
+                mask = size_n < boundary_m[:, None]
+                qk = tl.where(mask, qk, float("-inf"))
+        if IS_CAUSAL:
+            causal_boundary = start_n + offs_n_causal
+            causal_mask = OFFS_M[:, None] >= causal_boundary[None, :]
+            qk = tl.where(causal_mask, qk, float("-inf"))
+
+        # -- compute qk ----
+        if IS_EIGHT_BIT_GEMM:
+            qk += ((((tl.dot(q, k).to(tl.float32) * q_descale)) * k_descale) *
+                   QK_SCALE)
+        else:
+            if IS_EIGHT_BIT_KV:
+                k = (k * k_descale).to(q.type.element_ty)
+            qk += (tl.dot(q, k) * QK_SCALE)
+
+        if bias_ptrs is not None:
+            bias_offs_n = start_n + tl.arange(
+                0, BLOCK_N) if SHOULD_MASK_STEPS else None
+            bias = masked_load(bias_ptrs, OFFS_M, bias_offs_n, actual_seqlen_q,
+                               actual_seqlen_k)
+            # While bias is added after multiplying qk with sm_scale,
+            # our optimization to use 2^x instead of e^x results in an
+            # additional scale factor of log2(e) which we must also multiply
+            # the bias with.
+            qk += (bias * 1.44269504089)
+
+        if alibi_slope is not None:
+            # Compute the global position of each token within the sequence
+            global_m_positions = start_m * BLOCK_M + tl.arange(0, BLOCK_M)
+            global_n_positions = start_n + tl.arange(0, BLOCK_N)
+            alibi_block = compute_alibi_block(alibi_slope, actual_seqlen_q,
+                                              actual_seqlen_k,
+                                              global_m_positions,
+                                              global_n_positions)
+            qk += (alibi_block * 1.44269504089)  # scale factor of log2(e)
+
+        # softmax
+        m_ij = tl.maximum(m_i, tl.max(qk, 1))
+        qk = qk - m_ij[:, None]
+        p = tl.math.exp2(qk)
+
+        # CAVEAT: Must update l_ij before applying dropout
+        l_ij = tl.sum(p, 1)
+        if SHOULD_RETURN_ENCODED_SOFTMAX:
+            tl.store(encoded_sm_ptrs, p.to(encoded_sm_ptrs.type.element_ty))
+        # -- update output accumulator --
+        alpha = tl.math.exp2(m_i - m_ij)
+        acc = acc * alpha[:, None]
+        if not SHOULD_PRE_LOAD_V:
+            v = masked_load(v_ptrs, k_offs_n, k_offs_k, actual_seqlen_k,
+                            IS_ACTUAL_BLOCK_DMODEL)
+        # -- update m_i and l_i
+        l_i = l_i * alpha + l_ij
+        # update m_i and l_i
+        m_i = m_ij
+
+        if IS_EIGHT_BIT_GEMM:
+            if USE_P_SCALE:
+                p = quant_fp8(p, p_scale).to(QUANT_DTYPE)
+                acc += tl.dot(p, v)
+            else:
+                # v is in eight_bit but p is not, we want the gemm in p's type
+                acc += tl.dot(p, v.to(p.type.element_ty))
+        else:
+            if IS_EIGHT_BIT_KV:
+                v = (v * v_descale).to(p.type.element_ty)
+            acc += tl.dot(p.to(v.type.element_ty), v)
+
+        k_ptrs += BLOCK_N * stride_kn
+        v_ptrs += BLOCK_N * stride_vk
+        if bias_ptrs is not None:
+            bias_ptrs += BLOCK_N * stride_bn
+        if SHOULD_RETURN_ENCODED_SOFTMAX:
+            encoded_sm_ptrs += BLOCK_N
+    return acc, l_i, m_i
+
+
+def get_cdna_autotune_configs():
+    return [
+        triton.Config(
+            {
+                'BLOCK_M': 128,
+                'BLOCK_N': 128,
+                'waves_per_eu': 2,
+                'SHOULD_PRE_LOAD_V': False,
+                'GRID_CU_MULTIP': 2
+            },
+            num_stages=1,
+            num_warps=4),
+        triton.Config(
+            {
+                'BLOCK_M': 128,
+                'BLOCK_N': 64,
+                'waves_per_eu': 2,
+                'SHOULD_PRE_LOAD_V': False,
+                'GRID_CU_MULTIP': 2
+            },
+            num_stages=1,
+            num_warps=4),
+        triton.Config(
+            {
+                'BLOCK_M': 128,
+                'BLOCK_N': 64,
+                'waves_per_eu': 3,
+                'SHOULD_PRE_LOAD_V': False,
+                'GRID_CU_MULTIP': 2
+            },
+            num_stages=1,
+            num_warps=4),
+        triton.Config(
+            {
+                'BLOCK_M': 128,
+                'BLOCK_N': 64,
+                'waves_per_eu': 1,
+                'SHOULD_PRE_LOAD_V': False,
+                'GRID_CU_MULTIP': 2
+            },
+            num_stages=1,
+            num_warps=4),
+        triton.Config(
+            {
+                'BLOCK_M': 128,
+                'BLOCK_N': 32,
+                'waves_per_eu': 2,
+                'SHOULD_PRE_LOAD_V': False,
+                'GRID_CU_MULTIP': 2
+            },
+            num_stages=1,
+            num_warps=4),
+    ], [
+        'IS_CAUSAL', 'MAX_SEQLENS_Q', 'MAX_SEQLENS_K',
+        'IS_ACTUAL_BLOCK_DMODEL', 'VARLEN', 'HQ', 'HK'
+    ]
+
+
+def get_rdna_autotune_configs():
+    return [
+        triton.Config(
+            {
+                'BLOCK_M': 32,
+                'BLOCK_N': 32,
+                'waves_per_eu': 4,
+                'SHOULD_PRE_LOAD_V': False,
+                'GRID_CU_MULTIP': 2
+            },
+            num_stages=1,
+            num_warps=2),
+        triton.Config(
+            {
+                'BLOCK_M': 32,
+                'BLOCK_N': 32,
+                'waves_per_eu': 2,
+                'SHOULD_PRE_LOAD_V': False,
+                'GRID_CU_MULTIP': 2
+            },
+            num_stages=1,
+            num_warps=2),
+        triton.Config(
+            {
+                'BLOCK_M': 32,
+                'BLOCK_N': 16,
+                'waves_per_eu': 4,
+                'SHOULD_PRE_LOAD_V': False,
+                'GRID_CU_MULTIP': 2
+            },
+            num_stages=1,
+            num_warps=2),
+        triton.Config(
+            {
+                'BLOCK_M': 32,
+                'BLOCK_N': 16,
+                'waves_per_eu': 2,
+                'SHOULD_PRE_LOAD_V': False,
+                'GRID_CU_MULTIP': 2
+            },
+            num_stages=1,
+            num_warps=2),
+        triton.Config(
+            {
+                'BLOCK_M': 16,
+                'BLOCK_N': 16,
+                'waves_per_eu': 4,
+                'SHOULD_PRE_LOAD_V': False,
+                'GRID_CU_MULTIP': 2
+            },
+            num_stages=1,
+            num_warps=2),
+        triton.Config(
+            {
+                'BLOCK_M': 16,
+                'BLOCK_N': 16,
+                'waves_per_eu': 2,
+                'SHOULD_PRE_LOAD_V': False,
+                'GRID_CU_MULTIP': 2
+            },
+            num_stages=1,
+            num_warps=2),
+        # Fall-back config.
+        triton.Config(
+            {
+                'BLOCK_M': 16,
+                'BLOCK_N': 16,
+                'waves_per_eu': 1,
+                'SHOULD_PRE_LOAD_V': False,
+                'GRID_CU_MULTIP': 2
+            },
+            num_stages=1,
+            num_warps=2),
+    ], [
+        'IS_CAUSAL', 'MAX_SEQLENS_Q', 'MAX_SEQLENS_K',
+        'IS_ACTUAL_BLOCK_DMODEL', 'VARLEN', 'HQ', 'HK'
+    ]
+
+def get_gfx906_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_M": 32,
+                "BLOCK_N": 16,
+                "SHOULD_PRE_LOAD_V": False,
+                'GRID_CU_MULTIP': 2
+            },
+            num_stages=1,
+            num_warps=2),
+        triton.Config(
+            {
+                "BLOCK_M": 16,
+                "BLOCK_N": 16,
+                "SHOULD_PRE_LOAD_V": False,
+                'GRID_CU_MULTIP': 2
+            },
+            num_stages=1,
+            num_warps=2),
+    ], [
+        'IS_CAUSAL',
+        'IS_ACTUAL_BLOCK_DMODEL', 'VARLEN', 'HQ', 'HK'
+    ]
+
+def get_general_autotune_configs():
+    return [
+        triton.Config(
+            {
+                'BLOCK_M': 128,
+                'BLOCK_N': 128,
+                'SHOULD_PRE_LOAD_V': False,
+                'GRID_CU_MULTIP': 2
+            },
+            num_stages=1,
+            num_warps=4),
+        triton.Config(
+            {
+                'BLOCK_M': 128,
+                'BLOCK_N': 64,
+                'SHOULD_PRE_LOAD_V': False,
+                'GRID_CU_MULTIP': 2
+            },
+            num_stages=1,
+            num_warps=4),
+        triton.Config(
+            {
+                'BLOCK_M': 128,
+                'BLOCK_N': 32,
+                'SHOULD_PRE_LOAD_V': False,
+                'GRID_CU_MULTIP': 2
+            },
+            num_stages=1,
+            num_warps=4),
+    ], [
+        'IS_CAUSAL', 'MAX_SEQLENS_Q', 'MAX_SEQLENS_K',
+        'IS_ACTUAL_BLOCK_DMODEL', 'VARLEN', 'HQ', 'HK'
+    ]
+
+
+def has_gfx906_target():
+    ROCM_CDNA_TARGETS = ["gfx906"]
+    return triton.runtime.driver.active.get_current_target(
+    ).arch in ROCM_CDNA_TARGETS
+
+def has_cdna_target():
+    ROCM_CDNA_TARGETS = ["gfx942", "gfx90a", "gfx908"]
+    return triton.runtime.driver.active.get_current_target(
+    ).arch in ROCM_CDNA_TARGETS
+
+def is_rocm_gfx906():
+    return current_platform.is_rocm() and has_gfx906_target()
+
+def is_rocm_cdna():
+    return current_platform.is_rocm() and has_cdna_target()
+
+
+def get_autotune_configs():
+    if is_rocm_cdna():
+        return get_cdna_autotune_configs()
+    elif is_rocm_gfx906():
+        return get_gfx906_autotune_configs()
+    elif current_platform.is_rocm():
+        return get_rdna_autotune_configs()
+    else:
+        return get_general_autotune_configs()
+
+
+autotune_configs, autotune_keys = get_autotune_configs()
+
+
+@triton.autotune(
+    configs=autotune_configs,
+    key=autotune_keys,
+    use_cuda_graph=True,
+)
+@triton.jit
+def attn_fwd(
+    Q,
+    K,
+    V,
+    bias,
+    SM_SCALE: tl.constexpr,
+    L,
+    Out,
+    stride_qz: tl.int64,
+    stride_qh: tl.int64,
+    stride_qm: tl.int64,
+    stride_qk: tl.int64,
+    stride_kz: tl.int64,
+    stride_kh: tl.int64,
+    stride_kn: tl.int64,
+    stride_kk: tl.int64,
+    stride_vz: tl.int64,
+    stride_vh: tl.int64,
+    stride_vk: tl.int64,
+    stride_vn: tl.int64,
+    stride_oz: tl.int64,
+    stride_oh: tl.int64,
+    stride_om: tl.int64,
+    stride_on: tl.int64,
+    stride_bz: tl.int64,
+    stride_bh: tl.int64,
+    stride_bm: tl.int64,
+    stride_bn: tl.int64,
+    stride_az: tl.int64,
+    stride_ah: tl.int64,
+    q_descale_ptr,
+    k_descale_ptr,
+    p_scale_ptr,
+    p_descale_ptr,
+    o_descale_ptr,
+    v_descale_ptr,
+    q_descale_has_singleton: tl.constexpr,
+    k_descale_has_singleton: tl.constexpr,
+    p_descale_has_singleton: tl.constexpr,
+    v_descale_has_singleton: tl.constexpr,
+    cu_seqlens_q,
+    cu_seqlens_k,
+    philox_seed,
+    NUM_CU: tl.constexpr,
+    GRID_CU_MULTIP: tl.constexpr,
+    B: tl.constexpr,
+    philox_offset_base,
+    encoded_softmax,
+    alibi_slopes,
+    HQ: tl.constexpr,
+    HK: tl.constexpr,
+    IS_ACTUAL_BLOCK_DMODEL: tl.constexpr,
+    MAX_SEQLENS_Q: tl.constexpr,
+    MAX_SEQLENS_K: tl.constexpr,
+    VARLEN: tl.constexpr,
+    IS_CAUSAL: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_DMODEL: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    SHOULD_PRE_LOAD_V: tl.constexpr,
+    USE_BIAS: tl.constexpr,
+    SHOULD_RETURN_ENCODED_SOFTMAX: tl.constexpr,
+    USE_ALIBI: tl.constexpr,
+    IS_EIGHT_BIT: tl.constexpr,
+    USE_P_SCALE: tl.constexpr,
+    IS_EIGHT_BIT_KV: tl.constexpr,
+    QUANT_DTYPE: tl.constexpr = default_eight_bit_dtype_triton,
+):
+
+    if o_descale_ptr is not None:
+        o_descale = tl.load(o_descale_ptr)
+
+    start_m: tl.int64 = tl.program_id(0)
+    off_h_q: tl.int64 = tl.program_id(1)
+    off_z: tl.int64 = tl.program_id(2)
+
+    offs_m = start_m * BLOCK_M + tl.arange(0, BLOCK_M).to(tl.int64)
+    offs_n = tl.arange(0, BLOCK_N).to(tl.int64)
+    offs_d = tl.arange(0, BLOCK_DMODEL).to(tl.int64)
+
+    # as we can't have return statements inside while loop in Triton
+    continue_condition = True
+
+    if VARLEN:
+        cu_seqlens_q_start = tl.load(cu_seqlens_q + off_z)
+        cu_seqlens_q_end = tl.load(cu_seqlens_q + off_z + 1)
+        seqlen_q = cu_seqlens_q_end - cu_seqlens_q_start
+        # We have a one-size-fits-all grid in id(0). Some seqlens might be
+        # too small for all start_m so for those we return early.
+        if start_m * BLOCK_M > seqlen_q:
+            continue_condition = False
+            # return
+        cu_seqlens_k_start = tl.load(cu_seqlens_k + off_z)
+        cu_seqlens_k_end = tl.load(cu_seqlens_k + off_z + 1)
+        seqlen_k = cu_seqlens_k_end - cu_seqlens_k_start
+    else:
+        cu_seqlens_q_start = 0
+        cu_seqlens_k_start = 0
+        seqlen_q = MAX_SEQLENS_Q
+        seqlen_k = MAX_SEQLENS_K
+
+    if continue_condition:
+        # Now we compute whether we need to exit early due to causal
+        # masking. This is because for seqlen_q > seqlen_k, M rows of the
+        # attn scores are completely masked, resulting in 0s written to the
+        # output, and inf written to LSE. We don't need to do any GEMMs in
+        # this case. This block of code determines what N is, and if this
+        # WG is operating on those M rows.
+        n_blocks = cdiv_fn(seqlen_k, BLOCK_N)
+        if (IS_CAUSAL):
+            # If seqlen_q == seqlen_k, the attn scores are a square matrix.
+            # If seqlen_q != seqlen_k, attn scores are rectangular which
+            # means the causal mask boundary is bottom right aligned, and
+            # ends at either the top edge (seqlen_q < seqlen_k) or left
+            # edge. This captures the decrease in n_blocks if we have a
+            # rectangular attn matrix
+            n_blocks_seqlen = cdiv_fn(
+                (start_m + 1) * BLOCK_M + seqlen_k - seqlen_q, BLOCK_N)
+            # This is what adjusts the block_max for the current WG, only
+            # if IS_CAUSAL. Otherwise we want to always iterate through all
+            # n_blocks
+            n_blocks = min(n_blocks, n_blocks_seqlen)
+            # If we have no blocks after adjusting for seqlen deltas, this
+            # WG is part of the blocks that are all 0. We exit early.
+            if n_blocks <= 0:
+                o_offset = (Out + off_z * stride_oz + off_h_q * stride_oh +
+                            cu_seqlens_q_start * stride_om)
+                o_ptrs = (o_offset + offs_m[:, None] * stride_om +
+                          offs_d[None, :] * stride_on)
+                acc = tl.zeros([BLOCK_M, BLOCK_DMODEL], dtype=tl.float32)
+                o_ptrs_mask = (offs_m[:, None] < seqlen_q).broadcast_to(
+                    [BLOCK_M, BLOCK_DMODEL])
+                # We still need to write 0s to the result
+                tl.store(o_ptrs, acc, mask=o_ptrs_mask)
+                # The tensor allocated for L is based on MAX_SEQLENS_Q as
+                # that is statically known.
+                l_ptrs = (L + off_z * HQ * MAX_SEQLENS_Q +
+                          off_h_q * MAX_SEQLENS_Q + offs_m)
+                # We store inf to LSE, not -inf because in the bwd pass,
+                # we subtract this from qk which makes it -inf, such that
+                # exp(qk - inf) = 0 for these masked blocks.
+                l_value = tl.full([BLOCK_M],
+                                  value=float("inf"),
+                                  dtype=tl.float32)
+                l_ptrs_mask = offs_m < MAX_SEQLENS_Q
+                tl.store(l_ptrs, l_value, mask=l_ptrs_mask)
+                # TODO: Should dropout and return encoded softmax be
+                # handled here too?
+                continue_condition = False
+                # return
+
+        if continue_condition:
+            # If MQA / GQA, set the K and V head offsets appropriately.
+            GROUP_SIZE: tl.constexpr = HQ // HK
+            off_h_k = off_h_q // GROUP_SIZE if GROUP_SIZE != 1 else off_h_q
+            n_extra_tokens = 0
+            if seqlen_k < BLOCK_N:
+                n_extra_tokens = BLOCK_N - seqlen_k
+            elif seqlen_k % BLOCK_N:
+                n_extra_tokens = seqlen_k % BLOCK_N
+            USE_PADDED_HEAD: tl.constexpr = (IS_ACTUAL_BLOCK_DMODEL
+                                             != BLOCK_DMODEL)
+
+            # Compute pointers for all the tensors used in this kernel.
+            q_offset = (Q + off_z * stride_qz + off_h_q * stride_qh +
+                        cu_seqlens_q_start * stride_qm)
+            q_ptrs = (q_offset + offs_m[:, None] * stride_qm +
+                      offs_d[None, :] * stride_qk)
+            k_offset = (K + off_z * stride_kz + off_h_k * stride_kh +
+                        cu_seqlens_k_start * stride_kn)
+            k_ptrs = (k_offset + offs_d[:, None] * stride_kk +
+                      offs_n[None, :] * stride_kn)
+            v_offset = (V + off_z * stride_vz + off_h_k * stride_vh +
+                        cu_seqlens_k_start * stride_vk)
+            v_ptrs = (v_offset + offs_n[:, None] * stride_vk +
+                      offs_d[None, :] * stride_vn)
+            # Compute pointers for all scale tensors used in this kernel.
+
+            IS_EIGHT_BIT_GEMM: tl.constexpr = IS_EIGHT_BIT & (
+                not IS_EIGHT_BIT_KV)
+            if IS_EIGHT_BIT:
+                if k_descale_has_singleton:
+                    k_descale_ptrs = k_descale_ptr
+                else:
+                    k_descale_ptrs = k_descale_ptr + off_h_k
+
+                if v_descale_has_singleton:
+                    v_descale_ptrs = v_descale_ptr
+                else:
+                    v_descale_ptrs = v_descale_ptr + off_h_k
+
+                if not IS_EIGHT_BIT_KV:
+                    if q_descale_has_singleton:
+                        q_descale_ptrs = q_descale_ptr
+                    else:
+                        q_descale_ptrs = q_descale_ptr + off_h_q
+                if USE_P_SCALE:
+                    if p_descale_has_singleton:
+                        p_scale_ptrs = p_scale_ptr
+                        p_descale_ptrs = p_descale_ptr
+                    else:
+                        p_scale_ptrs = p_scale_ptr + off_h_q
+                        p_descale_ptrs = p_descale_ptr + off_h_q
+
+            if USE_BIAS:
+                bias_offset = off_h_q * stride_bh
+                bias_ptrs = (bias + bias_offset + offs_m[:, None] * stride_bm +
+                             offs_n[None, :] * stride_bn)
+            else:
+                bias_ptrs = None
+
+            if USE_ALIBI:
+                a_offset = off_z * stride_az + off_h_q * stride_ah
+                alibi_slope = tl.load(alibi_slopes + a_offset)
+            else:
+                alibi_slope = None
+
+            batch_philox_offset = 0
+            # We can ask to return the dropout mask without doing any
+            # dropout. In this case, we return an invalid pointer so
+            # indicate the mask is not valid.
+            if SHOULD_RETURN_ENCODED_SOFTMAX:
+                encoded_sm_base = (encoded_softmax +
+                                   off_h_q * seqlen_q * seqlen_k)
+                encoded_sm_ptrs = (encoded_sm_base +
+                                   offs_m[:, None] * seqlen_k +
+                                   offs_n[None, :])
+            else:
+                encoded_sm_ptrs = None
+            # initialize pointer to m and l
+            m_i = tl.full([BLOCK_M], float("-inf"), dtype=tl.float32)
+            l_i = tl.full([BLOCK_M], 1.0, dtype=tl.float32)
+            acc = tl.zeros([BLOCK_M, BLOCK_DMODEL], dtype=tl.float32)
+            # scale sm_scale by log_2(e) and use 2^x in the loop as we do
+            # not have native e^x support in HW.
+            QK_SCALE: tl.constexpr = SM_SCALE * 1.44269504089
+            # Q is loaded once at the beginning and shared by all N blocks.
+            q_ptrs_mask = offs_m[:, None] < seqlen_q
+            if USE_PADDED_HEAD:
+                q_ptrs_mask = q_ptrs_mask & (offs_d[None, :]
+                                             < IS_ACTUAL_BLOCK_DMODEL)
+            q = tl.load(q_ptrs, mask=q_ptrs_mask, other=0.0)
+
+            if IS_EIGHT_BIT:
+                k_descale = tl.load(k_descale_ptrs)
+                v_descale = tl.load(v_descale_ptrs)
+                q_descale = None if IS_EIGHT_BIT_KV else tl.load(
+                    q_descale_ptrs)
+                if USE_P_SCALE:
+                    p_scale = tl.load(p_scale_ptrs)
+                    p_descale = tl.load(p_descale_ptrs)
+                else:
+                    p_scale = None
+                    p_descale = None
+            else:
+                q_descale = None
+                k_descale = None
+                v_descale = None
+                p_scale = None
+                p_descale = None
+            # Here we compute how many full and masked blocks we have.
+            padded_block_k = n_extra_tokens != 0
+            is_modulo_mn = not padded_block_k and (seqlen_q % BLOCK_M == 0)
+            if IS_CAUSAL:
+                # There are always at least BLOCK_M // BLOCK_N masked
+                # blocks.  Additionally there might be one more due to
+                # dissimilar seqlens.
+                masked_blocks = BLOCK_M // BLOCK_N + (not is_modulo_mn)
+            else:
+                # Padding on Q does not need to be masked in the FA loop.
+                masked_blocks = padded_block_k
+            # if IS_CAUSAL, not is_modulo_mn does not always result in an
+            # additional block. In this case we might exceed n_blocks so
+            # pick the min.
+            masked_blocks = min(masked_blocks, n_blocks)
+            n_full_blocks = n_blocks - masked_blocks
+            block_min = 0
+            block_max = n_blocks * BLOCK_N
+            # Compute for full blocks. Here we set causal to false
+            # regardless of its actual value because there is no masking.
+            # Similarly we do not need padding.
+            if n_full_blocks > 0:
+                block_max = (n_blocks - masked_blocks) * BLOCK_N
+                acc, l_i, m_i = _attn_fwd_inner(
+                    acc,
+                    l_i,
+                    m_i,
+                    q,
+                    k_ptrs,
+                    v_ptrs,
+                    bias_ptrs,
+                    stride_kn,
+                    stride_vk,
+                    stride_bn,
+                    start_m,
+                    seqlen_k,
+                    seqlen_q,
+                    philox_seed,
+                    batch_philox_offset,
+                    encoded_sm_ptrs,
+                    # _, _, offs_n_causal, masked_blocks, n_extra_tokens, _
+                    block_min,
+                    block_max,
+                    0,
+                    0,
+                    0,
+                    alibi_slope,
+                    q_descale,
+                    k_descale,
+                    v_descale,
+                    p_scale,
+                    # IS_CAUSAL, ....
+                    False,
+                    BLOCK_M,
+                    BLOCK_DMODEL,
+                    BLOCK_N,
+                    offs_m,
+                    offs_n,
+                    # _, SHOULD_MASK_STEPS, ...
+                    SHOULD_PRE_LOAD_V,
+                    False,
+                    SHOULD_RETURN_ENCODED_SOFTMAX,
+                    USE_PADDED_HEAD,
+                    IS_ACTUAL_BLOCK_DMODEL,
+                    QK_SCALE,
+                    IS_EIGHT_BIT_GEMM,
+                    USE_P_SCALE,
+                    IS_EIGHT_BIT_KV,
+                    QUANT_DTYPE)
+                block_min = block_max
+                block_max = n_blocks * BLOCK_N
+
+            tl.debug_barrier()
+            # Remaining blocks, if any, are full / not masked.
+            if (masked_blocks > 0):
+                if IS_CAUSAL:
+                    offs_n_causal = offs_n + (seqlen_q - seqlen_k)
+                else:
+                    offs_n_causal = 0
+                k_ptrs += n_full_blocks * BLOCK_N * stride_kn
+                v_ptrs += n_full_blocks * BLOCK_N * stride_vk
+                if USE_BIAS:
+                    bias_ptrs += n_full_blocks * BLOCK_N * stride_bn
+                if SHOULD_RETURN_ENCODED_SOFTMAX:
+                    encoded_sm_ptrs += n_full_blocks * BLOCK_N
+                acc, l_i, m_i = _attn_fwd_inner(
+                    acc,
+                    l_i,
+                    m_i,
+                    q,
+                    k_ptrs,
+                    v_ptrs,
+                    bias_ptrs,
+                    stride_kn,
+                    stride_vk,
+                    stride_bn,
+                    start_m,
+                    seqlen_k,
+                    seqlen_q,
+                    philox_seed,
+                    batch_philox_offset,
+                    encoded_sm_ptrs,
+                    block_min,
+                    block_max,
+                    offs_n_causal,
+                    masked_blocks,
+                    n_extra_tokens,
+                    alibi_slope,
+                    q_descale,
+                    k_descale,
+                    v_descale,
+                    p_scale,
+                    IS_CAUSAL,
+                    BLOCK_M,
+                    BLOCK_DMODEL,
+                    BLOCK_N,
+                    offs_m,
+                    offs_n,
+                    # _, SHOULD_MASK_STEPS, ...
+                    SHOULD_PRE_LOAD_V,
+                    True,
+                    SHOULD_RETURN_ENCODED_SOFTMAX,
+                    USE_PADDED_HEAD,
+                    IS_ACTUAL_BLOCK_DMODEL,
+                    QK_SCALE,
+                    IS_EIGHT_BIT_GEMM,
+                    USE_P_SCALE,
+                    IS_EIGHT_BIT_KV,
+                    QUANT_DTYPE)
+
+            if IS_EIGHT_BIT and not IS_EIGHT_BIT_KV:
+                if USE_P_SCALE:
+                    acc *= p_descale
+                acc *= v_descale
+
+            # epilogue
+            # This helps the compiler do Newton Raphson on l_i vs on acc
+            # which is much larger.
+            l_recip = 1 / l_i[:, None]
+            acc = acc * l_recip
+
+            # If seqlen_q > seqlen_k but the delta is not a multiple of
+            # BLOCK_M, then we have one block with a row of all NaNs which
+            # come from computing softmax over a row of all
+            # -infs (-inf - inf = NaN). We check for that here and store 0s
+            # where there are NaNs as these rows should've been zeroed out.
+            end_m_idx = (start_m + 1) * BLOCK_M
+            start_m_idx = start_m * BLOCK_M
+            causal_start_idx = seqlen_q - seqlen_k
+            if IS_EIGHT_BIT and not IS_EIGHT_BIT_KV:  # noqa: SIM102
+                if o_descale_ptr is not None:
+                    acc = quant_fp8(acc, o_descale)
+
+            acc = acc.to(Out.type.element_ty)
+            if IS_CAUSAL:  # noqa: SIM102
+                if (causal_start_idx > start_m_idx
+                        and causal_start_idx < end_m_idx):
+                    out_mask_boundary = tl.full((BLOCK_DMODEL, ),
+                                                causal_start_idx,
+                                                dtype=tl.int32)
+                    mask_m_offsets = start_m_idx + tl.arange(0, BLOCK_M)
+                    out_ptrs_mask = (mask_m_offsets[:, None]
+                                     >= out_mask_boundary[None, :])
+                    z = tl.zeros((1, ), tl.float32)
+                    acc = tl.where(out_ptrs_mask, acc,
+                                   z.to(acc.type.element_ty))
+            # write back LSE
+            l_ptrs = (L + off_z * HQ * MAX_SEQLENS_Q +
+                      off_h_q * MAX_SEQLENS_Q + offs_m)
+            # If seqlen_q not multiple of BLOCK_M, we need to mask out the
+            # last few rows. This is only true for the last M block.
+            # For others, overflow_size will be -ve
+            overflow_size = end_m_idx - seqlen_q
+            if overflow_size > 0:
+                boundary = tl.full((BLOCK_M, ),
+                                   BLOCK_M - overflow_size,
+                                   dtype=tl.int32)
+                l_ptrs_mask = tl.arange(0, BLOCK_M) < boundary
+                tl.store(l_ptrs, m_i + tl.math.log2(l_i), mask=l_ptrs_mask)
+            else:
+                tl.store(l_ptrs, m_i + tl.math.log2(l_i))
+
+            # write back O
+            o_offset = (Out + off_z * stride_oz + off_h_q * stride_oh +
+                        cu_seqlens_q_start * stride_om)
+            o_ptrs = (o_offset + offs_m[:, None] * stride_om +
+                      offs_d[None, :] * stride_on)
+            o_ptrs_mask = tl.full([BLOCK_M, BLOCK_DMODEL], 1, dtype=tl.int1)
+            if overflow_size > 0:
+                o_ptrs_mask = o_ptrs_mask & (offs_m[:, None] < seqlen_q)
+            if USE_PADDED_HEAD:
+                o_ptrs_mask = o_ptrs_mask & (offs_d[None, :]
+                                             < IS_ACTUAL_BLOCK_DMODEL)
+            tl.store(o_ptrs, acc.to(Out.dtype.element_ty), mask=o_ptrs_mask)
+
+
+def get_shape_from_layout(q, k, metadata):
+    assert metadata.layout in SUPPORTED_LAYOUTS, "Got unsupported layout."
+
+    if metadata.layout == 'thd':
+        nheads_q, nheads_k = q.shape[1], k.shape[1]
+        head_size = q.shape[-1]
+        batch = metadata.num_contexts
+    elif metadata.layout == 'bhsd':
+        batch, nheads_q, _, head_size = q.shape
+        nheads_k = k.shape[1]
+    elif metadata.layout == 'bshd':
+        batch, _, nheads_q, head_size = q.shape
+        nheads_k = k.shape[2]
+    return batch, nheads_q, nheads_k, head_size
+
+
+def get_strides_from_layout(q, k, v, o, metadata):
+    assert metadata.layout in SUPPORTED_LAYOUTS, "Got unsupported layout."
+
+    STRIDE_PERMUTATIONS = {
+        'thd': (None, 1, 0, 2),
+        'bhsd': (0, 1, 2, 3),
+        'bshd': (0, 2, 1, 3),
+    }
+
+    perm = STRIDE_PERMUTATIONS[metadata.layout]
+    stride = lambda x, p: (0 if p is None else x.stride(p))
+    strides = lambda x: (stride(x, p) for p in perm)
+
+    return tuple(strides(x) for x in [q, k, v, o])
+
+
+class _attention(torch.autograd.Function):
+
+    @staticmethod
+    def forward(ctx, q, k, v, o, metadata: MetaData):
+        # NOTE: a large bias tensor leads to overflow during pointer arithmetic
+        if (metadata.bias is not None):
+            assert (metadata.bias.numel() < 2**31)
+
+        if o is None:
+            if metadata.eight_bit:
+                o = torch.empty_like(
+                    q,
+                    dtype=metadata.output_dtype if metadata.output_dtype
+                    is not None else metadata.eight_bit_dtype_torch)
+            else:
+                o = torch.empty_like(q, dtype=q.dtype)
+
+        metadata.check_args(q, k, v, o)
+
+        batch, nheads_q, nheads_k, head_size = get_shape_from_layout(
+            q, k, metadata)
+        q_strides, k_strides, v_strides, o_strides = get_strides_from_layout(
+            q, k, v, o, metadata)
+
+        # Get closest power of 2 over or equal to 32.
+        padded_d_model = 1 << (head_size - 1).bit_length()
+        # Smallest head_dim supported is 16. If smaller, the tile in the
+        # kernel is padded - there is no padding in memory for any dims.
+        padded_d_model = max(padded_d_model, 16)
+
+        # encoded_softmax is used to validate dropout behavior vs the
+        # PyTorch SDPA math backend reference.  We zero this out to give a
+        # consistent starting point and then populate it with the output of
+        # softmax with the sign bit set according to the dropout mask.
+        # The resulting return allows this mask to be fed into the reference
+        # implementation for testing only.  This return holds no useful output
+        # aside from debugging.
+        if metadata.return_encoded_softmax:
+            encoded_softmax = torch.zeros(
+                (q.shape[0], q.shape[1], q.shape[2], k.shape[2]),
+                device=q.device,
+                dtype=torch.float32)
+        else:
+            encoded_softmax = None
+
+        M = torch.empty((batch, nheads_q, metadata.max_seqlens_q),
+                        device=q.device,
+                        dtype=torch.float32)
+
+        # Seed the RNG so we get reproducible results for testing.
+        philox_seed = 0x1BF52
+        philox_offset = 0x1D4B42
+
+        if metadata.bias is not None:
+            bias_strides = (metadata.bias.stride(0), metadata.bias.stride(1),
+                            metadata.bias.stride(2), metadata.bias.stride(3))
+        else:
+            bias_strides = (0, 0, 0, 0)
+
+        if metadata.alibi_slopes is not None:
+            alibi_strides = (metadata.alibi_slopes.stride(0),
+                             metadata.alibi_slopes.stride(1))
+        else:
+            alibi_strides = (0, 0)
+
+        if metadata.eight_bit:
+            q_descale, k_descale, p_scale, p_descale, v_descale, o_scale = (
+                metadata.q_descale, metadata.k_descale, metadata.p_scale,
+                metadata.p_descale, metadata.v_descale, metadata.o_scale)
+            o_descale = 1.0 / o_scale if o_scale is not None else None
+        else:
+            q_descale = k_descale = p_scale = None
+            p_descale = v_descale = o_descale = None
+
+        # number of compute units available
+        NUM_CU = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+        grid = lambda META: (triton.cdiv(metadata.max_seqlens_q, META[
+            'BLOCK_M']), nheads_q, batch)
+
+        attn_fwd[grid](
+            q,
+            k,
+            v,
+            metadata.bias,
+            metadata.sm_scale,
+            M,
+            o,
+            *q_strides,
+            *k_strides,
+            *v_strides,
+            *o_strides,
+            *bias_strides,
+            *alibi_strides,
+            q_descale,
+            k_descale,
+            p_scale,
+            p_descale,
+            o_descale,
+            v_descale,
+            q_descale.numel() == 1 if q_descale is not None else False,
+            k_descale.numel() == 1 if k_descale is not None else False,
+            p_descale.numel() == 1 if p_descale is not None else False,
+            v_descale.numel() == 1 if v_descale is not None else False,
+            metadata.cu_seqlens_q,
+            metadata.cu_seqlens_k,
+            philox_seed=philox_seed,
+            philox_offset_base=philox_offset,
+            encoded_softmax=encoded_softmax,
+            alibi_slopes=metadata.alibi_slopes,
+            HQ=nheads_q,
+            HK=nheads_k,
+            IS_ACTUAL_BLOCK_DMODEL=head_size,
+            MAX_SEQLENS_Q=metadata.max_seqlens_q,
+            MAX_SEQLENS_K=metadata.max_seqlens_k,
+            IS_CAUSAL=metadata.causal,
+            VARLEN=metadata.varlen,
+            BLOCK_DMODEL=padded_d_model,
+            USE_BIAS=metadata.bias is not None,
+            USE_ALIBI=metadata.alibi_slopes is not None,
+            SHOULD_RETURN_ENCODED_SOFTMAX=metadata.return_encoded_softmax,
+            IS_EIGHT_BIT=metadata.eight_bit,
+            USE_P_SCALE=metadata.eight_bit and metadata.use_p_scale,
+            IS_EIGHT_BIT_KV=metadata.eight_bit and metadata.eight_bit_kv,
+            NUM_CU=NUM_CU,
+            B=batch,
+            QUANT_DTYPE=metadata.eight_bit_dtype_triton)
+
+        ctx.grid = grid
+        ctx.sm_scale = metadata.sm_scale
+        ctx.BLOCK_DMODEL = head_size
+        ctx.causal = metadata.causal
+        ctx.alibi_slopes = metadata.alibi_slopes
+        ctx.philox_seed = philox_seed
+        ctx.philox_offset = philox_offset
+        ctx.encoded_softmax = encoded_softmax
+        ctx.return_encoded_softmax = metadata.return_encoded_softmax
+        return o, encoded_softmax
+
+
+triton_attention_rocm = _attention.apply
+
+
+def scale_fp8(t, scale=None):
+    t_scaled, scale_out = ops.scaled_fp8_quant(t.reshape(-1, t.shape[-1]),
+                                               scale)
+    return t_scaled.reshape(t.shape), scale_out
+
+
+def maybe_quantize_fp8(t, scale):
+    eight_bit_dtype = current_platform.fp8_dtype()
+    if t.dtype != eight_bit_dtype:
+        t, _ = scale_fp8(t, scale)
+    return t
+
+
+def check_and_maybe_quantize_qkv(q, k, v, fp8_scales):
+    (q_scale, k_scale, v_scale, p_scale) = fp8_scales
+
+    q = maybe_quantize_fp8(q, q_scale)
+    k = maybe_quantize_fp8(k, k_scale)
+    v = maybe_quantize_fp8(v, v_scale)
+
+    return q, k, v
+
+
+# query   - [num_tokens, num_heads, head_size]
+# key     - [num_tokens, num_kv_heads, head_size]
+# value   - [num_tokens, num_kv_heads, head_size
+# output  - [num_tokens, num_heads, head_size]
+def triton_attention(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    o: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+    max_seqlens_q: int,
+    max_seqlens_k: int,
+    causal: bool = False,
+    sm_scale: float = 1.0,
+    bias: Optional[torch.Tensor] = None,
+    fp8_scales: Optional[tuple[float, ...]] = None,
+    input_scale: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    if fp8_scales is not None:
+        q_descale, k_descale, v_descale, p_scale = fp8_scales
+    else:
+        q_descale = k_descale = v_descale = p_scale = None
+
+    attn_metadata = MetaData(sm_scale=sm_scale,
+                             max_seqlens_q=max_seqlens_q,
+                             max_seqlens_k=max_seqlens_k,
+                             causal=causal,
+                             bias=bias,
+                             output_dtype=q.dtype,
+                             cu_seqlens_q=cu_seqlens_q,
+                             cu_seqlens_k=cu_seqlens_k,
+                             q_descale=q_descale,
+                             k_descale=k_descale,
+                             v_descale=v_descale,
+                             p_scale=p_scale,
+                             o_scale=input_scale)
+
+    if fp8_scales is not None:
+        q, k, v = check_and_maybe_quantize_qkv(q, k, v, fp8_scales)
+
+    return triton_attention_rocm(q, k, v, o, attn_metadata)

--- a/vllm/attention/utils/fa_utils.py
+++ b/vllm/attention/utils/fa_utils.py
@@ -18,7 +18,7 @@ elif current_platform.is_xpu():
     reshape_and_cache_flash = ops.reshape_and_cache_flash
     flash_attn_varlen_func = ops.flash_attn_varlen_func
     get_scheduler_metadata = ops.get_scheduler_metadata
-elif current_platform.is_rocm():
+elif current_platform.is_rocm() and not envs.VLLM_ROCM_USE_LEGACY_TRITON_FA:
     try:
         from flash_attn import flash_attn_varlen_func  # noqa: F401
     except ImportError as e:

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -86,7 +86,7 @@ TaskOption = Literal[
     "transcription",
     "draft",
 ]
-TokenizerMode = Literal["auto", "hf", "slow", "mistral"]
+TokenizerMode = Literal["auto", "hf", "slow", "mistral", "deepseek_v32"]
 ModelDType = Literal["auto", "half", "float16", "bfloat16", "float", "float32"]
 LogprobsMode = Literal[
     "raw_logits", "raw_logprobs", "processed_logits", "processed_logprobs"
@@ -143,6 +143,7 @@ class ModelConfig:
     - "hf" will use the fast tokenizer if available.\n
     - "slow" will always use the slow tokenizer.\n
     - "mistral" will always use the tokenizer from `mistral_common`.\n
+    - "deepseek_v32" will always use the tokenizer from `deepseek_v32`.\n
     - Other custom values can be supported via plugins."""
     trust_remote_code: bool = False
     """Trust remote code (e.g., from HuggingFace) when downloading the model

--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -106,7 +106,7 @@ from vllm.outputs import CompletionOutput, PoolingRequestOutput, RequestOutput
 from vllm.pooling_params import PoolingParams
 from vllm.reasoning import ReasoningParser, ReasoningParserManager
 from vllm.sampling_params import BeamSearchParams, SamplingParams
-from vllm.tokenizers import MistralTokenizer, TokenizerLike
+from vllm.tokenizers import DeepseekV32Tokenizer, MistralTokenizer, TokenizerLike
 from vllm.tracing import (
     contains_trace_headers,
     extract_trace_headers,
@@ -1127,6 +1127,13 @@ class OpenAIServing:
             request_prompt = await self._apply_mistral_chat_template_async(
                 tokenizer,
                 messages=messages,
+                **_chat_template_kwargs,
+            )
+        elif isinstance(tokenizer, DeepseekV32Tokenizer):
+            request_prompt = tokenizer.apply_chat_template(
+                conversation=conversation,
+                messages=messages,
+                model_config=model_config,
                 **_chat_template_kwargs,
             )
         else:

--- a/vllm/entrypoints/openai/tool_parsers/__init__.py
+++ b/vllm/entrypoints/openai/tool_parsers/__init__.py
@@ -30,6 +30,10 @@ _TOOL_PARSERS_TO_REGISTER = {
         "deepseekv31_tool_parser",
         "DeepSeekV31ToolParser",
     ),
+    "deepseek_v32": (
+        "deepseekv32_tool_parser",
+        "DeepSeekV32ToolParser",
+    ),
     "ernie45": (
         "ernie45_tool_parser",
         "Ernie45ToolParser",

--- a/vllm/entrypoints/openai/tool_parsers/deepseekv32_tool_parser.py
+++ b/vllm/entrypoints/openai/tool_parsers/deepseekv32_tool_parser.py
@@ -1,0 +1,591 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import json
+import uuid
+from collections.abc import Sequence
+from typing import Any
+
+import regex as re
+
+from vllm.entrypoints.openai.protocol import (
+    ChatCompletionRequest,
+    DeltaFunctionCall,
+    DeltaMessage,
+    DeltaToolCall,
+    ExtractedToolCallInformation,
+    FunctionCall,
+    ToolCall,
+)
+from vllm.entrypoints.openai.tool_parsers.abstract_tool_parser import (
+    ToolParser,
+)
+from vllm.logger import init_logger
+from vllm.tokenizers import TokenizerLike
+
+logger = init_logger(__name__)
+
+
+class DeepSeekV32ToolParser(ToolParser):
+    """
+    example tool call content:
+    <｜DSML｜function_calls>
+    <｜DSML｜invoke name="get_weather">
+    <｜DSML｜parameter name="location" string="true">杭州</｜DSML｜parameter>
+    <｜DSML｜parameter name="date" string="true">2024-01-16</｜DSML｜parameter>
+    </｜DSML｜invoke>
+    <｜DSML｜invoke name="get_weather">
+    <｜DSML｜parameter name="location" string="true">北京</｜DSML｜parameter>
+    <｜DSML｜parameter name="date" string="true">2024-01-16</｜DSML｜parameter>
+    </｜DSML｜invoke>
+    </｜DSML｜function_calls>
+    """
+
+    def __init__(self, tokenizer: TokenizerLike):
+        super().__init__(tokenizer)
+
+        self.prev_tool_call_arr: list[dict] = []
+
+        # Sentinel tokens
+        self.dsml_token: str = "｜DSML｜"
+        self.dsml_start_check: str = "<" + self.dsml_token
+        self.tool_call_start_token: str = "<｜DSML｜function_calls>"
+        self.tool_call_end_token: str = "</｜DSML｜function_calls>"
+        self.invoke_start_prefix: str = "<｜DSML｜invoke name="
+        self.invoke_end_token: str = "</｜DSML｜invoke>"
+        self.parameter_prefix: str = "<｜DSML｜parameter name="
+        self.parameter_end_token: str = "</｜DSML｜parameter>"
+
+        # Streaming state variables
+        self.current_tool_name_sent: bool = False
+        # Override base class type - we use string IDs for tool calls
+        self.current_tool_id: str | None = None  # type: ignore
+        self.streamed_args_for_tool: list[str] = []
+        self.is_tool_call_started: bool = False
+        self.failed_count: int = 0
+
+        # Initialize streaming state variables
+        self.current_tool_index: int = 0
+        self.invoke_index: int = 0
+        self.header_sent: bool = False
+        self.current_function_name: str | None = None
+        self.current_param_name: str | None = None
+        self.current_param_value: str = ""
+        self.param_count: int = 0
+        self.in_param: bool = False
+        self.in_function: bool = False
+        self.json_started: bool = False
+        self.json_closed: bool = False
+        self.accumulated_params: dict = {}
+        self.streaming_request: ChatCompletionRequest | None = None
+
+        # Enhanced streaming state - reset for each new message
+        self._reset_streaming_state()
+
+        # Regex patterns for complete parsing
+        self.tool_call_complete_regex = re.compile(
+            r"<｜DSML｜function_calls>(.*?)</｜DSML｜function_calls>", re.DOTALL
+        )
+        self.invoke_complete_regex = re.compile(
+            r'<｜DSML｜invoke\s+name="([^"]+)"\s*>(.*?)</｜DSML｜invoke>', re.DOTALL
+        )
+        self.parameter_complete_regex = re.compile(
+            r'<｜DSML｜parameter\s+name="([^"]+)"\s+string="(?:true|false)"\s*>(.*?)</｜DSML｜parameter>',
+            re.DOTALL,
+        )
+
+        if not self.model_tokenizer:
+            raise ValueError(
+                "The model tokenizer must be passed to the ToolParser "
+                "constructor during construction."
+            )
+
+        logger.debug(
+            "vLLM Successfully import tool parser %s !", self.__class__.__name__
+        )
+
+    def _generate_tool_call_id(self) -> str:
+        """Generate a unique tool call ID."""
+        return f"call_{uuid.uuid4().hex[:24]}"
+
+    def _reset_streaming_state(self):
+        """Reset all streaming state."""
+        self.current_tool_index = 0
+        self.invoke_index = 0
+        self.is_tool_call_started = False
+        self.header_sent = False
+        self.current_tool_id = None
+        self.current_function_name = None
+        self.current_param_name = None
+        self.current_param_value = ""
+        self.param_count = 0
+        self.in_param = False
+        self.in_function = False
+        self.json_started = False
+        self.json_closed = False
+        # Store accumulated parameters for type conversion
+        self.accumulated_params = {}
+        self.streaming_request = None
+        # Clear previous tool call history to avoid state pollution
+        self.prev_tool_call_arr.clear()
+
+    def _parse_invoke_params(self, invoke_str: str) -> dict | None:
+        param_dict = dict()
+        for param_name, param_val in self.parameter_complete_regex.findall(invoke_str):
+            param_dict[param_name] = param_val
+        return param_dict
+
+    def extract_tool_calls(
+        self,
+        model_output: str,
+        request: ChatCompletionRequest,
+    ) -> ExtractedToolCallInformation:
+        """Extract tool calls from complete model output (non-streaming)."""
+        # Quick check
+        if self.tool_call_start_token not in model_output:
+            return ExtractedToolCallInformation(
+                tools_called=False, tool_calls=[], content=model_output
+            )
+
+        try:
+            tool_calls = []
+
+            # Find all complete tool_call blocks
+            for tool_call_match in self.tool_call_complete_regex.findall(model_output):
+                # Find all invokes within this tool_call
+                for invoke_name, invoke_content in self.invoke_complete_regex.findall(
+                    tool_call_match
+                ):
+                    param_dict = self._parse_invoke_params(invoke_content)
+                    tool_calls.append(
+                        ToolCall(
+                            type="function",
+                            function=FunctionCall(
+                                name=invoke_name,
+                                arguments=json.dumps(param_dict, ensure_ascii=False),
+                            ),
+                        )
+                    )
+
+            if not tool_calls:
+                return ExtractedToolCallInformation(
+                    tools_called=False, tool_calls=[], content=model_output
+                )
+
+            # Extract content before first tool call
+            first_tool_idx = model_output.find(self.tool_call_start_token)
+            content = model_output[:first_tool_idx] if first_tool_idx > 0 else None
+
+            return ExtractedToolCallInformation(
+                tools_called=True, tool_calls=tool_calls, content=content
+            )
+
+        except Exception:
+            logger.exception("Error extracting tool calls")
+            return ExtractedToolCallInformation(
+                tools_called=False, tool_calls=[], content=model_output
+            )
+
+    def _extract_name(self, name_str: str) -> str:
+        """Extract name from quoted string."""
+        name_str = name_str.strip()
+        if (
+            name_str.startswith('"')
+            and name_str.endswith('"')
+            or name_str.startswith("'")
+            and name_str.endswith("'")
+        ):
+            return name_str[1:-1]
+        return name_str
+
+    def _extract_param_name(self, input_str: str) -> str:
+        """Extract param name"""
+        start = input_str.find('"') + 1
+        end = input_str.find('"', start)
+        return input_str[start:end] if start > 0 and end > start else input_str
+
+    def _convert_param_value(self, value: str, param_type: str) -> Any:
+        """Convert parameter value to the correct type."""
+        if value.lower() == "null":
+            return None
+
+        param_type = param_type.lower()
+        if param_type in ["string", "str", "text"]:
+            return value
+        elif param_type in ["integer", "int"]:
+            try:
+                return int(value)
+            except (ValueError, TypeError):
+                return value
+        elif param_type in ["number", "float"]:
+            try:
+                val = float(value)
+                return val if val != int(val) else int(val)
+            except (ValueError, TypeError):
+                return value
+        elif param_type in ["boolean", "bool"]:
+            return value.lower() in ["true", "1"]
+        elif param_type in ["object", "array"]:
+            try:
+                return json.loads(value)
+            except json.JSONDecodeError:
+                return value
+        else:
+            # Try JSON parse first, fallback to string
+            try:
+                return json.loads(value)
+            except json.JSONDecodeError:
+                return value
+
+    def extract_tool_calls_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int],  # pylint: disable=unused-argument
+        current_token_ids: Sequence[int],  # pylint: disable=unused-argument
+        delta_token_ids: Sequence[int],
+        request: ChatCompletionRequest,
+    ) -> DeltaMessage | None:
+        """Extract tool calls from streaming model output."""
+
+        # Store request for type conversion
+        if not previous_text:
+            self._reset_streaming_state()
+            self.streaming_request = request
+
+        # If no delta text, return None unless it's an EOS token after tools
+        if not delta_text:
+            # Check if this is an EOS token after all tool calls are complete
+            if delta_token_ids:
+                # Count complete tool calls
+                complete_calls = len(
+                    self.tool_call_complete_regex.findall(current_text)
+                )
+
+                # If we have completed tool calls and populated prev_tool_call_arr
+                if complete_calls > 0 and len(self.prev_tool_call_arr) > 0:
+                    # Check if all tool calls are closed
+                    open_calls = current_text.count(
+                        self.tool_call_start_token
+                    ) - current_text.count(self.tool_call_end_token)
+                    if open_calls == 0:
+                        # Return empty delta for finish_reason processing
+                        return DeltaMessage(content="")
+                elif not self.is_tool_call_started and current_text:
+                    # This is a regular content response that's now complete
+                    return DeltaMessage(content="")
+            return None
+
+        # Check if we need to advance to next tool
+        if self.json_closed and not self.in_function:
+            # Check if this tool call has ended
+            invoke_ends = current_text.count(self.invoke_end_token)
+            if invoke_ends > self.current_tool_index:
+                # This tool has ended, advance to next
+                self.current_tool_index += 1
+                self.header_sent = False
+                self.param_count = 0
+                self.json_started = False
+                self.json_closed = False
+                self.in_function = False  # Now we can safely set this to False
+                self.accumulated_params = {}
+                # Continue processing next tool
+                return None
+
+        # Handle normal content before tool calls
+        if not self.is_tool_call_started:
+            # Check if tool call is starting
+            if self.dsml_token in current_text:
+                self.is_tool_call_started = True
+                # Return any content before the tool call
+                if self.dsml_start_check in delta_text:
+                    content_before = delta_text[
+                        : delta_text.index(self.dsml_start_check)
+                    ]
+                    if content_before:
+                        return DeltaMessage(content=content_before)
+                return None
+            else:
+                # Check if we're between tool calls - skip whitespace
+                if (
+                    current_text.rstrip().endswith(self.tool_call_end_token)
+                    and delta_text.strip() == ""
+                ):
+                    # We just ended a tool call, skip whitespace
+                    return None
+                # Normal content, no tool call
+                if delta_text.endswith("<"):
+                    return DeltaMessage(content=delta_text[:-1])
+                if previous_text and previous_text.endswith("<"):
+                    return DeltaMessage(content="<" + delta_text)
+                return DeltaMessage(content=delta_text)
+
+        # Check if we're between tool calls (waiting for next one)
+        invoke_starts_count = current_text.count(self.invoke_start_prefix)
+        if self.current_tool_index >= invoke_starts_count:
+            # We're past all tool calls, shouldn't be here
+            return None
+
+        # Find the current tool call portion
+        invoke_start_positions: list[int] = []
+        idx = 0
+        while True:
+            idx = current_text.find(self.invoke_start_prefix, idx)
+            if idx == -1:
+                break
+            invoke_start_positions.append(idx)
+            idx += len(self.invoke_start_prefix)
+
+        if self.current_tool_index >= len(invoke_start_positions):
+            # No more tool calls to process yet
+            return None
+
+        invoke_start_idx = invoke_start_positions[self.current_tool_index]
+        # Find where this tool call ends (or current position if not ended yet)
+        invoke_end_idx = current_text.find(self.invoke_end_token, invoke_start_idx)
+        if invoke_end_idx == -1:
+            tool_text = current_text[invoke_start_idx:]
+        else:
+            tool_text = current_text[
+                invoke_start_idx : invoke_end_idx + len(self.invoke_end_token)
+            ]
+
+        # Looking for function header
+        if not self.header_sent:
+            if self.invoke_start_prefix in tool_text:
+                func_start = tool_text.find(self.invoke_start_prefix) + len(
+                    self.invoke_start_prefix
+                )
+                # Find the end quote for the function name
+                func_end = tool_text.find(">", func_start)
+
+                if func_end != -1:
+                    # Found complete function name
+                    function_name_raw = tool_text[func_start:func_end]
+                    self.current_function_name = self._extract_name(function_name_raw)
+                    self.current_tool_id = self._generate_tool_call_id()
+                    self.header_sent = True
+                    self.in_function = True
+
+                    # Add to prev_tool_call_arr immediately when we detect a tool call
+                    # Each tool call should be recorded regardless of function name
+                    # Ensure we don't add the same tool call index multiple times
+                    if len(self.prev_tool_call_arr) <= self.current_tool_index:
+                        self.prev_tool_call_arr.append(
+                            {
+                                "name": self.current_function_name,
+                                "arguments": "{}",  # Placeholder, will be updated later
+                            }
+                        )
+
+                    # Send header with function info
+                    return DeltaMessage(
+                        tool_calls=[
+                            DeltaToolCall(
+                                index=self.current_tool_index,
+                                id=self.current_tool_id,
+                                function=DeltaFunctionCall(
+                                    name=self.current_function_name, arguments=""
+                                ),
+                                type="function",
+                            )
+                        ]
+                    )
+            return None
+
+        # We've sent header, now handle function body
+        if self.in_function:
+            # Send opening brace if not sent yet
+            if self.in_function and not self.json_started:
+                self.json_started = True
+                return DeltaMessage(
+                    tool_calls=[
+                        DeltaToolCall(
+                            index=self.current_tool_index,
+                            function=DeltaFunctionCall(arguments="{"),
+                        )
+                    ]
+                )
+
+            # Make sure json_started is set if we're processing parameters
+            if not self.json_started:
+                self.json_started = True
+
+            # Check for function end in accumulated text
+            if not self.json_closed and self.invoke_end_token in tool_text:
+                # Count total parameters in the tool text
+                total_param_count = tool_text.count(self.parameter_prefix)
+
+                # Only close JSON if all parameters have been processed
+                if self.param_count >= total_param_count:
+                    # Close JSON
+                    self.json_closed = True
+
+                    # Extract complete tool call
+                    # Find the invoke content
+                    invoke_start = tool_text.find(self.invoke_start_prefix) + len(
+                        self.invoke_start_prefix
+                    )
+                    invoke_content_end = tool_text.find(
+                        self.invoke_end_token, invoke_start
+                    )
+                    if invoke_content_end != -1:
+                        invoke_content = tool_text[invoke_start:invoke_content_end]
+                        # Parse to get the complete arguments
+                        try:
+                            invoke_params = self._parse_invoke_params(invoke_content)
+                            if invoke_params and self.current_tool_index < len(
+                                self.prev_tool_call_arr
+                            ):
+                                # Update existing entry in prev_tool_call_arr
+                                self.prev_tool_call_arr[self.current_tool_index][
+                                    "arguments"
+                                ] = json.dumps(invoke_params, ensure_ascii=False)
+                        except Exception:
+                            pass  # Ignore parsing errors during streaming
+
+                    result = DeltaMessage(
+                        tool_calls=[
+                            DeltaToolCall(
+                                index=self.current_tool_index,
+                                function=DeltaFunctionCall(arguments="}"),
+                            )
+                        ]
+                    )
+
+                    # Reset state for next tool
+                    self.json_closed = True
+                    self.in_function = False
+                    self.accumulated_params = {}
+
+                    logger.debug("[M2_STREAMING] Tool call completed")
+
+                    return result
+                else:
+                    # Don't close JSON yet, continue processing parameters
+                    return None
+
+            # Look for parameters
+            # Find all parameter starts
+            param_starts = []
+            idx = 0
+            while True:
+                idx = tool_text.find(self.parameter_prefix, idx)
+                if idx == -1:
+                    break
+                param_starts.append(idx)
+                idx += len(self.parameter_prefix)
+
+            # Check if we should start a new parameter
+            if (
+                not self.in_param
+                and self.param_count < len(param_starts)
+                and len(param_starts) > self.param_count
+            ):
+                # Process the next parameter
+                param_idx = param_starts[self.param_count]
+                param_start = param_idx + len(self.parameter_prefix)
+                remaining = tool_text[param_start:]
+
+                if ">" in remaining:
+                    # We have the complete parameter name
+                    name_end = remaining.find(">")
+                    param_name_raw = remaining[:name_end]
+                    self.current_param_name = self._extract_param_name(param_name_raw)
+
+                    # Find the parameter value
+                    value_start = param_start + name_end + 1
+                    value_text = tool_text[value_start:]
+                    if value_text.startswith("\n"):
+                        value_text = value_text[1:]
+
+                    # Find where this parameter ends
+                    param_end_idx = value_text.find(self.parameter_end_token)
+                    if param_end_idx == -1:
+                        # No closing tag, look for next parameter or function end
+                        next_param_idx = value_text.find(self.parameter_prefix)
+                        func_end_idx = value_text.find(self.invoke_end_token)
+
+                        if next_param_idx != -1 and (
+                            func_end_idx == -1 or next_param_idx < func_end_idx
+                        ):
+                            param_end_idx = next_param_idx
+                        elif func_end_idx != -1:
+                            param_end_idx = func_end_idx
+                        else:
+                            # Neither found, check if tool call is complete
+                            if self.invoke_end_token in tool_text:
+                                # Tool call and parameter is complete
+                                param_end_idx = len(value_text)
+                            else:
+                                # Still streaming, wait for more content
+                                return None
+
+                    if param_end_idx != -1:
+                        # Complete parameter found
+                        param_value = value_text[:param_end_idx]
+                        if param_value.endswith("\n"):
+                            param_value = param_value[:-1]
+
+                        # Store raw value for later processing
+                        self.accumulated_params[self.current_param_name] = param_value
+
+                        # Get parameter configuration for type conversion
+                        param_config = {}
+                        if self.streaming_request and self.streaming_request.tools:
+                            for tool in self.streaming_request.tools:
+                                if (
+                                    hasattr(tool, "function")
+                                    and tool.function.name == self.current_function_name
+                                    and hasattr(tool.function, "parameters")
+                                ):
+                                    params = tool.function.parameters
+                                    if (
+                                        isinstance(params, dict)
+                                        and "properties" in params
+                                    ):
+                                        param_config = params["properties"]
+                                    break
+
+                        # Get parameter type
+                        param_type = "string"
+                        if (
+                            self.current_param_name in param_config
+                            and isinstance(param_config[self.current_param_name], dict)
+                            and "type" in param_config[self.current_param_name]
+                        ):
+                            param_type = param_config[self.current_param_name]["type"]
+
+                        # Convert param value to appropriate type
+                        converted_value = self._convert_param_value(
+                            param_value, param_type
+                        )
+
+                        # Build JSON fragment based on the converted type
+                        # Use json.dumps to properly serialize the value
+                        serialized_value = json.dumps(
+                            converted_value, ensure_ascii=False
+                        )
+
+                        if self.param_count == 0:
+                            json_fragment = (
+                                f'"{self.current_param_name}": {serialized_value}'
+                            )
+                        else:
+                            json_fragment = (
+                                f', "{self.current_param_name}": {serialized_value}'
+                            )
+
+                        self.param_count += 1
+
+                        return DeltaMessage(
+                            tool_calls=[
+                                DeltaToolCall(
+                                    index=self.current_tool_index,
+                                    function=DeltaFunctionCall(arguments=json_fragment),
+                                )
+                            ]
+                        )
+
+        return None

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any, Literal
 if TYPE_CHECKING:
     VLLM_MLA_SPARSE_DISABLE_EXPERIMENTAL: bool = False
     VLLM_ROCM_USE_LEGACY_TRITON_FA: bool = False
+    VLLM_ROCM_USE_AITER_MLA_SPARSE_FP16: bool = False
     VLLM_HOST_IP: str = ""
     VLLM_PORT: int | None = None
     VLLM_RPC_BASE_PATH: str = tempfile.gettempdir()
@@ -917,6 +918,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     "VLLM_ROCM_USE_LEGACY_TRITON_FA": lambda: (
         os.environ.get("VLLM_ROCM_USE_LEGACY_TRITON_FA", "0").strip().lower()
+        in ("1", "true")
+    ),
+    "VLLM_ROCM_USE_AITER_MLA_SPARSE_FP16": lambda: (
+        os.environ.get("VLLM_ROCM_USE_AITER_MLA_SPARSE_FP16", "0").strip().lower()
         in ("1", "true")
     ),
     # We assume drivers can report p2p status correctly.

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -11,6 +11,8 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
+    VLLM_MLA_SPARSE_DISABLE_EXPERIMENTAL: bool = False
+    VLLM_ROCM_USE_LEGACY_TRITON_FA: bool = False
     VLLM_HOST_IP: str = ""
     VLLM_PORT: int | None = None
     VLLM_RPC_BASE_PATH: str = tempfile.gettempdir()
@@ -907,6 +909,14 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # If set, allow loading or unloading lora adapters in runtime,
     "VLLM_ALLOW_RUNTIME_LORA_UPDATING": lambda: (
         os.environ.get("VLLM_ALLOW_RUNTIME_LORA_UPDATING", "0").strip().lower()
+        in ("1", "true")
+    ),
+    "VLLM_MLA_SPARSE_DISABLE_EXPERIMENTAL": lambda: (
+        os.environ.get("VLLM_MLA_SPARSE_DISABLE_EXPERIMENTAL", "0").strip().lower()
+        in ("1", "true")
+    ),
+    "VLLM_ROCM_USE_LEGACY_TRITON_FA": lambda: (
+        os.environ.get("VLLM_ROCM_USE_LEGACY_TRITON_FA", "0").strip().lower()
         in ("1", "true")
     ),
     # We assume drivers can report p2p status correctly.

--- a/vllm/model_executor/layers/fused_moe/configs/E=256,N=128,device_name=AMD_Radeon_Graphics,dtype=int4_w4a16.json
+++ b/vllm/model_executor/layers/fused_moe/configs/E=256,N=128,device_name=AMD_Radeon_Graphics,dtype=int4_w4a16.json
@@ -1,0 +1,10 @@
+{
+    "1024": {"BLOCK_SIZE_M": 64, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 128, "SPLIT_K": 1,
+             "GROUP_SIZE_M": 8, "num_warps": 4, "num_stages": 1},
+    "2048": {"BLOCK_SIZE_M": 64, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 128, "SPLIT_K": 1,
+             "GROUP_SIZE_M": 8, "num_warps": 4, "num_stages": 1},
+    "4096": {"BLOCK_SIZE_M": 64, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 128, "SPLIT_K": 1,
+             "GROUP_SIZE_M": 8, "num_warps": 4, "num_stages": 1},
+    "8192": {"BLOCK_SIZE_M": 64, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 128, "SPLIT_K": 1,
+             "GROUP_SIZE_M": 8, "num_warps": 4, "num_stages": 1}
+}

--- a/vllm/model_executor/layers/fused_moe/configs/E=256,N=256,device_name=AMD_Radeon_Graphics,dtype=int4_w4a16.json
+++ b/vllm/model_executor/layers/fused_moe/configs/E=256,N=256,device_name=AMD_Radeon_Graphics,dtype=int4_w4a16.json
@@ -1,0 +1,10 @@
+{
+    "1024": {"BLOCK_SIZE_M": 64, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 128, "SPLIT_K": 1,
+             "GROUP_SIZE_M": 8, "num_warps": 4, "num_stages": 1},
+    "2048": {"BLOCK_SIZE_M": 64, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 128, "SPLIT_K": 1,
+             "GROUP_SIZE_M": 8, "num_warps": 4, "num_stages": 1},
+    "4096": {"BLOCK_SIZE_M": 64, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 128, "SPLIT_K": 1,
+             "GROUP_SIZE_M": 8, "num_warps": 4, "num_stages": 1},
+    "8192": {"BLOCK_SIZE_M": 64, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 128, "SPLIT_K": 1,
+             "GROUP_SIZE_M": 8, "num_warps": 4, "num_stages": 1}
+}

--- a/vllm/model_executor/layers/fused_moe/configs/E=256,N=512,device_name=AMD_Radeon_Graphics,dtype=int4_w4a16.json
+++ b/vllm/model_executor/layers/fused_moe/configs/E=256,N=512,device_name=AMD_Radeon_Graphics,dtype=int4_w4a16.json
@@ -1,0 +1,10 @@
+{
+    "1024": {"BLOCK_SIZE_M": 64, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 128, "SPLIT_K": 1,
+             "GROUP_SIZE_M": 8, "num_warps": 4, "num_stages": 1},
+    "2048": {"BLOCK_SIZE_M": 64, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 128, "SPLIT_K": 1,
+             "GROUP_SIZE_M": 8, "num_warps": 4, "num_stages": 1},
+    "4096": {"BLOCK_SIZE_M": 64, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 128, "SPLIT_K": 1,
+             "GROUP_SIZE_M": 8, "num_warps": 4, "num_stages": 1},
+    "8192": {"BLOCK_SIZE_M": 64, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 128, "SPLIT_K": 1,
+             "GROUP_SIZE_M": 8, "num_warps": 4, "num_stages": 1}
+}

--- a/vllm/model_executor/layers/quantization/auto_round.py
+++ b/vllm/model_executor/layers/quantization/auto_round.py
@@ -51,6 +51,7 @@ class AutoRoundConfig(QuantizationConfig):
         extra_config: dict[str, Any] | None = None,
         data_type: str = "int",
         backend: str = "auto",
+        checkpoint_format: str = "",
     ) -> None:
         super().__init__()
         if weight_bits not in self.SUPPORTED_BITS:
@@ -87,6 +88,7 @@ class AutoRoundConfig(QuantizationConfig):
         self.data_type = data_type
         self.backend = backend
         self.pack_factor = Fraction(32, weight_bits)
+        self.checkpoint_format = checkpoint_format
 
     def __repr__(self) -> str:
         return (
@@ -125,6 +127,7 @@ class AutoRoundConfig(QuantizationConfig):
             extra_config=cls.get_from_keys_or(config, ["extra_config"], None),
             data_type=cls.get_from_keys_or(config, ["data_type"], "int"),
             backend=cls.get_from_keys_or(config, ["backend", "vllm_backend"], "auto"),
+            checkpoint_format=cls.get_from_keys_or(config, ["checkpoint_format"], ""),
         )
 
     def get_layer_config(self, layer, layer_name: str):
@@ -374,6 +377,7 @@ class AutoRoundConfig(QuantizationConfig):
                 lm_head_quantized=False,
                 desc_act=False,
                 dynamic={},
+                checkpoint_format=self.checkpoint_format,
             )
 
         if isinstance(layer, FusedMoE):
@@ -448,7 +452,11 @@ class AutoRoundConfig(QuantizationConfig):
             or self.backend == "ipex"
         ):
             return self.apply_ipex_quant_layer(layer, prefix)
+        
+        # FIX: Pass self.backend to the quant layer methods to avoid default backend auto falling back to marlin
         if "gptq" in self.packing_format or "gptq" in self.backend:
-            return self.apply_gptq_quant_layer(layer, prefix)
+            return self.apply_gptq_quant_layer(layer, prefix, self.backend)
         if "awq" in self.packing_format or "awq" in self.backend:
-            return self.apply_awq_quant_layer(layer, prefix)
+            return self.apply_awq_quant_layer(layer, prefix, self.backend)
+        
+        return None

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -601,45 +601,6 @@ class DeepseekV32IndexerCache(torch.nn.Module, AttentionLayerBase):
         return DeepseekV32IndexerBackend
 
 
-def gather_k_from_cache(kv_cache, block_table, cu_seq_lens, head_dim):
-    """
-    Non Optimized vibe coded python gather (avoids torch.cat overhead by pre-allocating the result).
-    """
-    # 1. Pre-allocate the full output tensor at once
-    # We know the total size is the last cumulative sequence length
-    total_tokens = cu_seq_lens[-1].item()
-    k_out = torch.empty((total_tokens, head_dim), dtype=kv_cache.dtype, device=kv_cache.device)
-    
-    batch_size = block_table.shape[0]
-    block_size = kv_cache.shape[1]
-    
-    # 2. Iterate and fill (In-place copy)
-    for i in range(batch_size):
-        # Indices for the destination tensor
-        start_idx = cu_seq_lens[i].item()
-        end_idx = cu_seq_lens[i+1].item()
-        seq_len = end_idx - start_idx
-        
-        if seq_len == 0:
-            continue
-            
-        # Indices for the source cache
-        num_blocks = (seq_len + block_size - 1) // block_size
-        block_ids = block_table[i, :num_blocks].to(torch.long)
-        
-        # Gather blocks: [Num_Blocks, Block_Size, Head_Dim]
-        # Using advanced indexing here invokes a fast C++ kernel in PyTorch background
-        blocks = kv_cache[block_ids]
-        
-        # Reshape to linear and trim padding
-        # .view() is zero-copy, so this is fast
-        valid_k = blocks.view(-1, head_dim)[:seq_len]
-        
-        # Copy into the pre-allocated buffer
-        k_out[start_idx:end_idx].copy_(valid_k)
-        
-    return k_out
-
 def sparse_attn_indexer(
     hidden_states: torch.Tensor,
     k_cache_prefix: str,
@@ -691,22 +652,11 @@ def sparse_attn_indexer(
             scale_fmt,
         )
     else:
-        # --------------------------------------------------------------------------
-        # STEP 1: Cache Population (Write)
-        # --------------------------------------------------------------------------
-        if slot_mapping is not None:
-            # kv_cache is already [Blocks, BlockSize, 128]
-            flat_cache = kv_cache.view(-1, head_dim)
-            
-            # --- FIX: Trust slot_mapping as the "Real" count ---
-            num_slots = slot_mapping.numel()
-            
-            # Slice k to remove the CUDA graph padding
-            k_valid = k[:num_slots]
-            
-            # Write valid data to valid slots
-            flat_cache.index_copy_(0, slot_mapping, k_valid)
-
+        ops.indexer_k_cache_fp16(
+            k,
+            kv_cache,
+            slot_mapping,
+        )
 
     topk_indices_buffer[: hidden_states.shape[0]] = -1
     if has_prefill:
@@ -731,26 +681,22 @@ def sparse_attn_indexer(
                     chunk.cu_seq_lens,
                 )
             else:
-                # ------------------------------------------------------------------
-                # STEP 2: Key Retrieval (Read GLOBAL History + Current)
-                # ------------------------------------------------------------------
-                # FIX: We cannot use k[chunk.start:chunk.end] because 'k' only contains
-                # the *new* tokens in this forward pass. We need the full history
-                # (including previous chunks) which now resides in kv_cache.
-                
-                # Using the helper function to gather K from the cache we just wrote to
-                k_fp = gather_k_from_cache(
-                    kv_cache=kv_cache,
-                    block_table=chunk.block_table,
-                    cu_seq_lens=chunk.cu_seq_lens,
-                    head_dim=head_dim
+                k_fp = torch.empty(
+                    [chunk.total_seq_lens, head_dim],
+                    device=k.device,
+                    dtype=torch.float16,
+                )
+                ops.cp_gather_indexer_k_cache_fp16(
+                    kv_cache,
+                    k_fp,
+                    chunk.block_table,
+                    chunk.cu_seq_lens,
                 )
             
             mqa_logits_func = fp8_mqa_logits
             if current_platform.is_rocm():
-                from vllm.attention.ops.rocm_aiter_mla_sparse import rocm_fp8_mqa_logits
-                from vllm.attention.ops.rocm_aiter_mla_sparse import fp16_mqa_logits_torch
-                mqa_logits_func = fp16_mqa_logits_torch if envs.VLLM_ROCM_USE_AITER_MLA_SPARSE_FP16 else rocm_fp8_mqa_logits
+                from vllm.attention.ops.rocm_aiter_mla_sparse import rocm_mqa_logits
+                mqa_logits_func = rocm_mqa_logits
             
             logits = mqa_logits_func(
                 q[chunk.token_start : chunk.token_end], # q is valid to slice (current only), fp16 or fp8
@@ -802,12 +748,11 @@ def sparse_attn_indexer(
         paged_mqa_logits_func = fp8_paged_mqa_logits
         if current_platform.is_rocm():
             from vllm.attention.ops.rocm_aiter_mla_sparse import (
-                rocm_fp8_paged_mqa_logits,
+                rocm_paged_mqa_logits,
             )
-            from vllm.attention.ops.rocm_aiter_mla_sparse import fp16_paged_mqa_logits_torch
 
 
-            paged_mqa_logits_func = fp16_paged_mqa_logits_torch if envs.VLLM_ROCM_USE_AITER_MLA_SPARSE_FP16 else rocm_fp8_paged_mqa_logits
+            paged_mqa_logits_func = rocm_paged_mqa_logits
         logits = paged_mqa_logits_func(
             padded_q_decode_tokens, # fp16 or fp8
             kv_cache, # fp16 or fp8
@@ -877,25 +822,23 @@ def sparse_attn_indexer_fake(
         )
 
     if envs.VLLM_ATTENTION_BACKEND=="ROCM_AITER_MLA_SPARSE" and not envs.VLLM_ROCM_USE_AITER: 
-        # 1. Prefill Memory (Chunked)
-        # TODO: Make HEAD_CHUNK_SIZE as env variable if the non optimized vibe coded pytorch ops is still used in future build
-        # As HEAD_CHUNK_SIZE is also used in vllm/attention/ops/rocm_aiter_mla_sparse.py
-        HEAD_CHUNK_SIZE = 1
+        # In the profile run, q.shape[0] is typically max_num_batched_tokens (2048)
+        batch_size = q.shape[0]
         
-        # Calculate worst-case memory for one chunk
-        # TODO: To be fixed as that's not the real worst-case memory (tests with 16 MI50 shows +6% VRAM / GPU from gpu-memory-utilization value at peak)  
-        # Shape: [Chunk_Size, Q_Tokens, History_Len]
-        prefill_elements = HEAD_CHUNK_SIZE * q.shape[0] * total_seq_lens
-
-        # 2. Decode Memory
-        # Shape: [Batch_Size, Max_Model_Len]
-        # In decode, q.shape[0] is batch_size
-        decode_elements = q.shape[0] * max_model_len
-
-        # 3. Maximize
-        max_elements = max(prefill_elements, decode_elements)
-        _mimic_logits = torch.empty(
-            max_elements,
+        # We simulate the worst-case logits allocation.
+        # Even though Triton uses 1 tensor, we allocate 2x to create a safety buffer 
+        # against fragmentation and overhead from the Gather ops.
+        
+        # Buffer 1: The theoretical logits
+        _mimic_logits_1 = torch.empty(
+            (batch_size, max_model_len),
+            device=q.device, 
+            dtype=torch.float32 
+        )
+        
+        # Buffer 2: The safety padding (forces vLLM to reserve extra free VRAM)
+        _mimic_logits_2 = torch.empty(
+            (batch_size, max_model_len),
             device=q.device, 
             dtype=torch.float32 
         )

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -28,6 +28,7 @@ import typing
 from collections.abc import Callable, Iterable
 from itertools import islice
 
+import vllm.envs as envs
 import torch
 from torch import nn
 from transformers import DeepseekV2Config, DeepseekV3Config
@@ -1033,7 +1034,8 @@ class DeepseekV2MLAAttention(nn.Module):
             mscale = yarn_get_mscale(scaling_factor, float(mscale_all_dim))
             self.scaling = self.scaling * mscale * mscale
 
-        self.is_v32 = hasattr(config, "index_topk")
+        # MLA Sparse (with Indexer) introduced by DS v3.2 can be enabled or not (EXPERIMENTAL)
+        self.is_v32 = False if envs.VLLM_MLA_SPARSE_DISABLE_EXPERIMENTAL else hasattr(config, "index_topk")
 
         if self.is_v32:
             self.indexer_rope_emb = get_rope(
@@ -1679,7 +1681,14 @@ class DeepseekV2ForCausalLM(
 
                         if is_pp_missing_parameter(name, self):
                             continue
-
+                        # ========================================================
+                        # Ignore Indexer Weights of MLA Sparse if VLLM_MLA_SPARSE_DISABLE_EXPERIMENTAL 
+                        # (it might disable MTP as well which depends on indexer)
+                        # ========================================================
+                        if envs.VLLM_MLA_SPARSE_DISABLE_EXPERIMENTAL and name not in params_dict:
+                            if "indexer" in name:
+                                continue
+                        # ========================================================
                         param = params_dict[name]
                         weight_loader = getattr(
                             param, "weight_loader", default_weight_loader

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -601,11 +601,50 @@ class DeepseekV32IndexerCache(torch.nn.Module, AttentionLayerBase):
         return DeepseekV32IndexerBackend
 
 
+def gather_k_from_cache(kv_cache, block_table, cu_seq_lens, head_dim):
+    """
+    Non Optimized vibe coded python gather (avoids torch.cat overhead by pre-allocating the result).
+    """
+    # 1. Pre-allocate the full output tensor at once
+    # We know the total size is the last cumulative sequence length
+    total_tokens = cu_seq_lens[-1].item()
+    k_out = torch.empty((total_tokens, head_dim), dtype=kv_cache.dtype, device=kv_cache.device)
+    
+    batch_size = block_table.shape[0]
+    block_size = kv_cache.shape[1]
+    
+    # 2. Iterate and fill (In-place copy)
+    for i in range(batch_size):
+        # Indices for the destination tensor
+        start_idx = cu_seq_lens[i].item()
+        end_idx = cu_seq_lens[i+1].item()
+        seq_len = end_idx - start_idx
+        
+        if seq_len == 0:
+            continue
+            
+        # Indices for the source cache
+        num_blocks = (seq_len + block_size - 1) // block_size
+        block_ids = block_table[i, :num_blocks].to(torch.long)
+        
+        # Gather blocks: [Num_Blocks, Block_Size, Head_Dim]
+        # Using advanced indexing here invokes a fast C++ kernel in PyTorch background
+        blocks = kv_cache[block_ids]
+        
+        # Reshape to linear and trim padding
+        # .view() is zero-copy, so this is fast
+        valid_k = blocks.view(-1, head_dim)[:seq_len]
+        
+        # Copy into the pre-allocated buffer
+        k_out[start_idx:end_idx].copy_(valid_k)
+        
+    return k_out
+
 def sparse_attn_indexer(
     hidden_states: torch.Tensor,
     k_cache_prefix: str,
     kv_cache: torch.Tensor,
-    q_fp8: torch.Tensor,
+    q: torch.Tensor,
     k: torch.Tensor,
     weights: torch.Tensor,
     quant_block_size: int,
@@ -625,7 +664,7 @@ def sparse_attn_indexer(
             hidden_states,
             k_cache_prefix,
             kv_cache,
-            q_fp8,
+            q,
             k,
             weights,
             quant_block_size,
@@ -642,45 +681,81 @@ def sparse_attn_indexer(
     has_decode = attn_metadata.num_decodes > 0
     has_prefill = attn_metadata.num_prefills > 0
     num_decode_tokens = attn_metadata.num_decode_tokens
+    
+    if not envs.VLLM_ROCM_USE_AITER_MLA_SPARSE_FP16:
+        ops.indexer_k_quant_and_cache(
+            k,
+            kv_cache,
+            slot_mapping,
+            quant_block_size,
+            scale_fmt,
+        )
+    else:
+        # --------------------------------------------------------------------------
+        # STEP 1: Cache Population (Write)
+        # --------------------------------------------------------------------------
+        if slot_mapping is not None:
+            # kv_cache is already [Blocks, BlockSize, 128]
+            flat_cache = kv_cache.view(-1, head_dim)
+            
+            # --- FIX: Trust slot_mapping as the "Real" count ---
+            num_slots = slot_mapping.numel()
+            
+            # Slice k to remove the CUDA graph padding
+            k_valid = k[:num_slots]
+            
+            # Write valid data to valid slots
+            flat_cache.index_copy_(0, slot_mapping, k_valid)
 
-    ops.indexer_k_quant_and_cache(
-        k,
-        kv_cache,
-        slot_mapping,
-        quant_block_size,
-        scale_fmt,
-    )
 
     topk_indices_buffer[: hidden_states.shape[0]] = -1
     if has_prefill:
         prefill_metadata = attn_metadata.prefill
         for chunk in prefill_metadata.chunks:
-            k_fp8 = torch.empty(
-                [chunk.total_seq_lens, head_dim],
-                device=k.device,
-                dtype=fp8_dtype,
-            )
-            k_scale = torch.empty(
-                [chunk.total_seq_lens, 4],
-                device=k.device,
-                dtype=torch.uint8,
-            )
-            ops.cp_gather_indexer_k_quant_cache(
-                kv_cache,
-                k_fp8,
-                k_scale,
-                chunk.block_table,
-                chunk.cu_seq_lens,
-            )
-            fp8_mqa_logits_func = fp8_mqa_logits
+            if not envs.VLLM_ROCM_USE_AITER_MLA_SPARSE_FP16:
+                k_fp = torch.empty(
+                    [chunk.total_seq_lens, head_dim],
+                    device=k.device,
+                    dtype=fp8_dtype,
+                )
+                k_scale = torch.empty(
+                    [chunk.total_seq_lens, 4],
+                    device=k.device,
+                    dtype=torch.uint8,
+                )
+                ops.cp_gather_indexer_k_quant_cache(
+                    kv_cache,
+                    k_fp,
+                    k_scale,
+                    chunk.block_table,
+                    chunk.cu_seq_lens,
+                )
+            else:
+                # ------------------------------------------------------------------
+                # STEP 2: Key Retrieval (Read GLOBAL History + Current)
+                # ------------------------------------------------------------------
+                # FIX: We cannot use k[chunk.start:chunk.end] because 'k' only contains
+                # the *new* tokens in this forward pass. We need the full history
+                # (including previous chunks) which now resides in kv_cache.
+                
+                # Using the helper function to gather K from the cache we just wrote to
+                k_fp = gather_k_from_cache(
+                    kv_cache=kv_cache,
+                    block_table=chunk.block_table,
+                    cu_seq_lens=chunk.cu_seq_lens,
+                    head_dim=head_dim
+                )
+            
+            mqa_logits_func = fp8_mqa_logits
             if current_platform.is_rocm():
                 from vllm.attention.ops.rocm_aiter_mla_sparse import rocm_fp8_mqa_logits
-
-                fp8_mqa_logits_func = rocm_fp8_mqa_logits
-            logits = fp8_mqa_logits_func(
-                q_fp8[chunk.token_start : chunk.token_end],
-                (k_fp8, k_scale.view(torch.float32)),
-                weights[chunk.token_start : chunk.token_end],
+                from vllm.attention.ops.rocm_aiter_mla_sparse import fp16_mqa_logits_torch
+                mqa_logits_func = fp16_mqa_logits_torch if envs.VLLM_ROCM_USE_AITER_MLA_SPARSE_FP16 else rocm_fp8_mqa_logits
+            
+            logits = mqa_logits_func(
+                q[chunk.token_start : chunk.token_end], # q is valid to slice (current only), fp16 or fp8
+                k_fp if envs.VLLM_ROCM_USE_AITER_MLA_SPARSE_FP16 else (k_fp, k_scale.view(torch.float32)),   # k MUST be full history,  fp16 or fp8
+                weights[chunk.token_start : chunk.token_end], # fp32
                 chunk.cu_seqlen_ks,
                 chunk.cu_seqlen_ke,
             )
@@ -689,7 +764,7 @@ def sparse_attn_indexer(
             topk_indices = topk_indices_buffer[
                 chunk.token_start : chunk.token_end, :topk_tokens
             ]
-            torch.ops._C.top_k_per_row(
+            torch.ops._C.top_k_per_row_prefill(
                 logits,
                 chunk.cu_seqlen_ks,
                 chunk.cu_seqlen_ke,
@@ -697,6 +772,7 @@ def sparse_attn_indexer(
                 num_rows,
                 logits.stride(0),
                 logits.stride(1),
+                topk_tokens,
             )
 
     if has_decode:
@@ -710,29 +786,32 @@ def sparse_attn_indexer(
             # decode_threshold since we unstrictly split
             # prefill and decode by decode_threshold
             # (currently set to 1 + speculative tokens)
-            padded_q_fp8_decode_tokens = pack_seq_triton(
-                q_fp8[:num_decode_tokens], decode_lens
+            padded_q_decode_tokens = pack_seq_triton(
+                q[:num_decode_tokens], decode_lens
             )
         else:
-            padded_q_fp8_decode_tokens = q_fp8[:num_decode_tokens].reshape(
-                decode_lens.shape[0], -1, *q_fp8.shape[1:]
+            padded_q_decode_tokens = q[:num_decode_tokens].reshape(
+                decode_lens.shape[0], -1, *q.shape[1:]
             )
         # TODO: move and optimize below logic with triton kernels
-        batch_size = padded_q_fp8_decode_tokens.shape[0]
-        next_n = padded_q_fp8_decode_tokens.shape[1]
+        batch_size = padded_q_decode_tokens.shape[0]
+        next_n = padded_q_decode_tokens.shape[1]
         assert batch_size == decode_metadata.seq_lens.shape[0]
         num_padded_tokens = batch_size * next_n
-        fp8_paged_mqa_logits_func = fp8_paged_mqa_logits
+        
+        paged_mqa_logits_func = fp8_paged_mqa_logits
         if current_platform.is_rocm():
             from vllm.attention.ops.rocm_aiter_mla_sparse import (
                 rocm_fp8_paged_mqa_logits,
             )
+            from vllm.attention.ops.rocm_aiter_mla_sparse import fp16_paged_mqa_logits_torch
 
-            fp8_paged_mqa_logits_func = rocm_fp8_paged_mqa_logits
-        logits = fp8_paged_mqa_logits_func(
-            padded_q_fp8_decode_tokens,
-            kv_cache,
-            weights[:num_padded_tokens],
+
+            paged_mqa_logits_func = fp16_paged_mqa_logits_torch if envs.VLLM_ROCM_USE_AITER_MLA_SPARSE_FP16 else rocm_fp8_paged_mqa_logits
+        logits = paged_mqa_logits_func(
+            padded_q_decode_tokens, # fp16 or fp8
+            kv_cache, # fp16 or fp8
+            weights[:num_padded_tokens], # fp32
             decode_metadata.seq_lens,
             decode_metadata.block_table,
             decode_metadata.schedule_metadata,
@@ -750,6 +829,7 @@ def sparse_attn_indexer(
             num_rows,
             logits.stride(0),
             logits.stride(1),
+            topk_tokens,
         )
         if decode_metadata.requires_padding:
             # if padded, we need to unpack
@@ -769,7 +849,7 @@ def sparse_attn_indexer_fake(
     hidden_states: torch.Tensor,
     k_cache_prefix: str,
     kv_cache: torch.Tensor,
-    q_fp8: torch.Tensor,
+    q: torch.Tensor,
     k: torch.Tensor,
     weights: torch.Tensor,
     quant_block_size: int,
@@ -783,12 +863,43 @@ def sparse_attn_indexer_fake(
     # profile run
     # NOTE(Chen): create the max possible flattened_kv. So that
     # profile_run can get correct memory usage.
-    _flattened_kv = torch.empty(
-        [total_seq_lens, head_dim + 4], device=k.device, dtype=torch.uint8
-    )
-    fp8_dtype = current_platform.fp8_dtype()
-    _k_fp8 = _flattened_kv[..., :head_dim].view(fp8_dtype).contiguous()
-    _k_scale = _flattened_kv[..., head_dim:].view(torch.float32).contiguous()
+
+    if not envs.VLLM_ROCM_USE_AITER_MLA_SPARSE_FP16:
+        _flattened_kv = torch.empty(
+            [total_seq_lens, head_dim + 4], device=k.device, dtype=torch.uint8
+        )
+        fp8_dtype = current_platform.fp8_dtype()
+        _k_fp8 = _flattened_kv[..., :head_dim].view(fp8_dtype).contiguous()
+        _k_scale = _flattened_kv[..., head_dim:].view(torch.float32).contiguous()
+    else:
+        _flattened_k = torch.empty(
+            [total_seq_lens, head_dim], device=k.device, dtype=torch.float16
+        )
+
+    if envs.VLLM_ATTENTION_BACKEND=="ROCM_AITER_MLA_SPARSE" and not envs.VLLM_ROCM_USE_AITER: 
+        # 1. Prefill Memory (Chunked)
+        # TODO: Make HEAD_CHUNK_SIZE as env variable if the non optimized vibe coded pytorch ops is still used in future build
+        # As HEAD_CHUNK_SIZE is also used in vllm/attention/ops/rocm_aiter_mla_sparse.py
+        HEAD_CHUNK_SIZE = 1
+        
+        # Calculate worst-case memory for one chunk
+        # TODO: To be fixed as that's not the real worst-case memory (tests with 16 MI50 shows +6% VRAM / GPU from gpu-memory-utilization value at peak)  
+        # Shape: [Chunk_Size, Q_Tokens, History_Len]
+        prefill_elements = HEAD_CHUNK_SIZE * q.shape[0] * total_seq_lens
+
+        # 2. Decode Memory
+        # Shape: [Batch_Size, Max_Model_Len]
+        # In decode, q.shape[0] is batch_size
+        decode_elements = q.shape[0] * max_model_len
+
+        # 3. Maximize
+        max_elements = max(prefill_elements, decode_elements)
+        _mimic_logits = torch.empty(
+            max_elements,
+            device=q.device, 
+            dtype=torch.float32 
+        )
+
     return topk_indices_buffer
 
 
@@ -839,7 +950,11 @@ class Indexer(nn.Module):
         )
         self.k_norm = LayerNorm(self.head_dim, eps=1e-6)
         self.weights_proj = ReplicatedLinear(
-            hidden_size, self.n_head, quant_config=None, prefix=f"{prefix}.weights_proj"
+            hidden_size,
+            self.n_head,
+            bias=False,
+            quant_config=None,
+            prefix=f"{prefix}.weights_proj",
         )
         self.softmax_scale = self.head_dim**-0.5
 
@@ -851,8 +966,8 @@ class Indexer(nn.Module):
         #       where we store value in fp8 and scale in fp32
         #       per self.quant_block_size element
         self.k_cache = DeepseekV32IndexerCache(
-            head_dim=self.head_dim + self.head_dim // self.quant_block_size * 4,
-            dtype=torch.uint8,
+            head_dim=self.head_dim if envs.VLLM_ROCM_USE_AITER_MLA_SPARSE_FP16 else self.head_dim + self.head_dim // self.quant_block_size * 4,
+            dtype=torch.float16 if envs.VLLM_ROCM_USE_AITER_MLA_SPARSE_FP16 else torch.uint8,
             prefix=f"{prefix}.k_cache",
             cache_config=cache_config,
         )
@@ -878,19 +993,26 @@ class Indexer(nn.Module):
         )
 
         q_pe, k_pe = rotary_emb(positions, q_pe, k_pe.unsqueeze(1))
-        q = torch.cat([q_pe.squeeze(0), q_nope], dim=-1)
-        k = torch.cat([k_pe.squeeze((0, 2)), k_nope], dim=-1)
-
+        # Note: RoPE (NeoX) can introduce extra leading dimensions during compilation
+        # so we need to reshape back to token-flattened shapes
+        q_pe = q_pe.reshape(-1, self.n_head, self.rope_dim)
+        k_pe = k_pe.reshape(-1, 1, self.rope_dim)
+        q = torch.cat([q_pe, q_nope], dim=-1)
+        # `k_pe` is [num_tokens, 1, rope_dim] (MQA).
+        k = torch.cat([k_pe.squeeze(-2), k_nope], dim=-1)
         # we only quant q here since k quant is fused with cache insertion
-        q = q.view(-1, self.head_dim)
-        q_fp8, q_scale = per_token_group_quant_fp8(
-            q,
-            self.quant_block_size,
-            column_major_scales=False,
-            use_ue8m0=self.scale_fmt is not None,
-        )
-        q_fp8 = q_fp8.view(-1, self.n_head, self.head_dim)
-        q_scale = q_scale.view(-1, self.n_head, 1)
+        if not envs.VLLM_ROCM_USE_AITER_MLA_SPARSE_FP16:
+            q = q.view(-1, self.head_dim)
+            q, q_scale = per_token_group_quant_fp8(
+                q,
+                self.quant_block_size,
+                column_major_scales=False,
+                use_ue8m0=self.scale_fmt is not None,
+            )
+            q = q.view(-1, self.n_head, self.head_dim)
+            q_scale = q_scale.view(-1, self.n_head, 1)
+        else:
+            q_scale = 1
 
         weights, _ = self.weights_proj(hidden_states)
         weights = (
@@ -900,11 +1022,11 @@ class Indexer(nn.Module):
 
         return torch.ops.vllm.sparse_attn_indexer(
             hidden_states,
-            self.k_cache.prefix,
-            self.k_cache.kv_cache[0],
-            q_fp8,
-            k,
-            weights,
+            self.k_cache.prefix, # fp16 or fp8
+            self.k_cache.kv_cache[0], # fp16 or fp8
+            q, # fp16 or fp8
+            k, # fp16 or fp8
+            weights, # fp32
             self.quant_block_size,
             self.scale_fmt,
             self.topk_tokens,
@@ -1595,7 +1717,11 @@ class DeepseekV2ForCausalLM(
                     # Determine split axis based on op type
                     # gate/up: ColumnParallel → split along dim 0
                     # down: RowParallel → split along dim 1
-                    split_dim = 1 if "down_proj.weight" in name else 0
+                    split_dim = (
+                        1
+                        if ("down_proj.weight" in name and loaded_weight.ndim > 1)
+                        else 0
+                    )
                     total = loaded_weight.shape[split_dim]
                     assert total % num_chunks == 0, (
                         f"Shared expert weight dim {total} "
@@ -1608,14 +1734,13 @@ class DeepseekV2ForCausalLM(
                     weight_to_load = loaded_weight
 
                     if is_fusion_moe_shared_experts_layer:
-                        if split_dim == 0:
-                            weight_to_load = loaded_weight[
-                                j * chunk_size : (j + 1) * chunk_size, :
-                            ]
+                        chunk_slice = slice(j * chunk_size, (j + 1) * chunk_size)
+                        if loaded_weight.ndim == 1:
+                            weight_to_load = loaded_weight[chunk_slice]
+                        elif split_dim == 0:
+                            weight_to_load = loaded_weight[chunk_slice, :]
                         else:
-                            weight_to_load = loaded_weight[
-                                :, j * chunk_size : (j + 1) * chunk_size
-                            ]
+                            weight_to_load = loaded_weight[:, chunk_slice]
                         # Synthesize an expert-style name so expert mapping
                         # can route it
                         chunk_name = name.replace(

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -239,9 +239,8 @@ class RocmPlatform(Platform):
                 raise ValueError(
                     "ROCMAiterMLASparseBackend doesn't support fp8 kv_cache_dtype."
                 )
-            assert block_size == 1, (
-                "Sparse MLA backend on ROCm only supports block size 1 for now."
-            )
+            # Sparse MLA backend - compatible with multiple block size if VLLM_ROCM_USE_AITER=0 using pytorch ops 
+            # If VLLM_ROCM_USE_AITER=1, only block size = 1 supported for now
             logger.info_once("Using Sparse MLA backend on V1 engine.")
             return AttentionBackendEnum.ROCM_AITER_MLA_SPARSE.get_path()
 

--- a/vllm/reasoning/deepseek_v3_reasoning_parser.py
+++ b/vllm/reasoning/deepseek_v3_reasoning_parser.py
@@ -26,6 +26,8 @@ class DeepSeekV3ReasoningParser(ReasoningParser):
 
         chat_kwargs = kwargs.pop("chat_template_kwargs", {}) or {}
         thinking = bool(chat_kwargs.pop("thinking", False))
+        enable_thinking = bool(chat_kwargs.pop("enable_thinking", False))
+        thinking = thinking or enable_thinking
 
         if thinking:
             self._parser = DeepSeekR1ReasoningParser(tokenizer, *args, **kwargs)

--- a/vllm/tokenizers/__init__.py
+++ b/vllm/tokenizers/__init__.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from .deepseekv32 import DeepseekV32Tokenizer
 from .hf import HfTokenizer
 from .mistral import MistralTokenizer
 from .protocol import TokenizerLike
@@ -21,4 +22,5 @@ __all__ = [
     "get_tokenizer",
     "cached_tokenizer_from_config",
     "init_tokenizer_from_config",
+    "DeepseekV32Tokenizer",
 ]

--- a/vllm/tokenizers/deepseek_v32_encoding.py
+++ b/vllm/tokenizers/deepseek_v32_encoding.py
@@ -1,0 +1,464 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+
+# copy from https://huggingface.co/deepseek-ai/DeepSeek-V3.2/blob/main/encoding/encoding_dsv32.py
+import copy
+import json
+from typing import Any
+
+import regex as re
+
+# flake8: noqa: E501
+TOOLS_SYSTEM_TEMPLATE = """## Tools
+You have access to a set of tools you can use to answer the user's question.
+You can invoke functions by writing a "<{dsml_token}function_calls>" block like the following as part of your reply to the user:
+<{dsml_token}function_calls>
+<{dsml_token}invoke name="$FUNCTION_NAME">
+<{dsml_token}parameter name="$PARAMETER_NAME" string="true|false">$PARAMETER_VALUE</{dsml_token}parameter>
+...
+</{dsml_token}invoke>
+<{dsml_token}invoke name="$FUNCTION_NAME2">
+...
+</{dsml_token}invoke>
+</{dsml_token}function_calls>
+String and scalar parameters should be specified as is without any escaping or quotes, while lists and objects should use JSON format. The "string" attribute should be set to "true" for string type parameters and "false" for other types (numbers, booleans, arrays, objects).
+If the thinking_mode is enabled, then after function results you should strongly consider outputting a thinking block. Here is an example:
+<{dsml_token}function_calls>
+...
+</{dsml_token}function_calls>
+<function_results>
+...
+</function_results>
+{thinking_start_token}...thinking about results{thinking_end_token}
+Here are the functions available in JSONSchema format:
+<functions>
+{tool_schemas}
+</functions>
+"""
+
+bos_token: str = "<｜begin▁of▁sentence｜>"
+eos_token: str = "<｜end▁of▁sentence｜>"
+thinking_start_token: str = "<think>"
+thinking_end_token: str = "</think>"
+dsml_token: str = "｜DSML｜"
+system_msg_template: str = "{content}"
+user_msg_template: str = "<｜User｜>{content}<｜Assistant｜>"
+assistant_msg_template: str = "{reasoning}{content}{tool_calls}<｜end▁of▁sentence｜>"
+thinking_template = "{reasoning_content}"
+
+response_format_template: str = "## Response Format:\n\nYou MUST strictly adhere to the following schema to reply:\n{schema}"
+tool_call_template: str = (
+    '<{dsml_token}invoke name="{name}">\n{arguments}\n</{dsml_token}invoke>'
+)
+tool_calls_template = (
+    "<{dsml_token}function_calls>\n{tool_calls}\n</{dsml_token}function_calls>"
+)
+
+tool_output_template: str = "\n<result>{content}</result>"
+
+
+def to_json(value: Any) -> str:
+    try:
+        return json.dumps(value, ensure_ascii=False)
+    except Exception:
+        return json.dumps(value, ensure_ascii=True)
+
+
+def tools_from_openai_format(tools):
+    return [tool["function"] for tool in tools]
+
+
+def tool_calls_from_openai_format(tool_calls):
+    return [
+        {
+            "name": tool_call["function"]["name"],
+            "arguments": tool_call["function"]["arguments"],
+        }
+        for tool_call in tool_calls
+    ]
+
+
+def tool_calls_to_openai_format(tool_calls):
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": tool_call["name"],
+                "arguments": tool_call["arguments"],
+            },
+        }
+        for tool_call in tool_calls
+    ]
+
+
+def encode_arguments_to_dsml(tool_call: dict[str, str]) -> str:
+    p_dsml_template = """<{dsml_token}parameter name="{key}" string="{is_str}">{value}</{dsml_token}parameter>"""
+    P_dsml_strs = []
+
+    if isinstance(tool_call["arguments"], str):
+        arguments = json.loads(tool_call["arguments"])
+    else:
+        arguments = tool_call["arguments"]
+
+    for k, v in arguments.items():
+        p_dsml_str = p_dsml_template.format(
+            dsml_token=dsml_token,
+            key=k,
+            is_str="true" if isinstance(v, str) else "false",
+            value=v if isinstance(v, str) else to_json(v),
+        )
+
+        P_dsml_strs.append(p_dsml_str)
+
+    return "\n".join(P_dsml_strs)
+
+
+def decode_dsml_to_arguments(
+    tool_name: str, tool_args: dict[str, tuple[str, str]]
+) -> dict[str, str]:
+    def _decode_value(key: str, value: str, string: str):
+        if string == "true":
+            value = to_json(value)
+        return f"{to_json(key)}: {value}"
+
+    tool_args_json = (
+        "{"
+        + ", ".join(
+            [_decode_value(k, v, string=is_str) for k, (v, is_str) in tool_args.items()]
+        )
+        + "}"
+    )
+    return dict(name=tool_name, arguments=tool_args_json)
+
+
+def render_tools(tools: list[dict[str, str | dict[str, Any]]]) -> str:
+    tools_json = [to_json(t) for t in tools]
+
+    return TOOLS_SYSTEM_TEMPLATE.format(
+        tool_schemas="\n".join(tools_json),
+        dsml_token=dsml_token,
+        thinking_start_token=thinking_start_token,
+        thinking_end_token=thinking_end_token,
+    )
+
+
+def find_last_user_index(messages: list[dict[str, Any]]) -> int:
+    last_user_index = -1
+    for idx in range(len(messages) - 1, -1, -1):
+        if messages[idx].get("role") in ["user", "developer"]:
+            last_user_index = idx
+            break
+    return last_user_index
+
+
+def render_message(
+    index: int, messages: list[dict[str, Any]], thinking_mode: str
+) -> str:
+    assert 0 <= index < len(messages)
+    assert thinking_mode in ["chat", "thinking"], (
+        f"Invalid thinking_mode `{thinking_mode}`"
+    )
+
+    prompt = ""
+    msg = messages[index]
+    last_user_idx = find_last_user_index(messages)
+
+    role = msg.get("role")
+    content = msg.get("content")
+    tools = msg.get("tools")
+    response_format = msg.get("response_format")
+    tool_calls = msg.get("tool_calls")
+    reasoning_content = msg.get("reasoning") or msg.get("reasoning_content")
+    is_prefix = msg.get("prefix", False)
+
+    if tools:
+        tools = tools_from_openai_format(tools)
+    if tool_calls:
+        tool_calls = tool_calls_from_openai_format(tool_calls)
+
+    if role == "system":
+        prompt += system_msg_template.format(content=content or "")
+        if tools:
+            prompt += "\n\n" + render_tools(tools)
+
+        if response_format:
+            prompt += "\n\n" + response_format_template.format(
+                schema=to_json(response_format)
+            )
+
+    elif role == "developer":
+        assert content, f"Invalid message for role `{role}`: {msg}"
+        content_developer = ""
+        if tools:
+            content_developer += "\n\n" + render_tools(tools)
+
+        if response_format:
+            content_developer += "\n\n" + response_format_template.format(
+                schema=to_json(response_format)
+            )
+
+        content_developer += "\n\n# The user's message is: {}".format(content)
+
+        prompt += user_msg_template.format(content=content_developer)
+        if index == last_user_idx and thinking_mode == "thinking":
+            prompt += thinking_start_token
+        else:
+            prompt += thinking_end_token
+
+    elif role == "user":
+        prompt += user_msg_template.format(content=content)
+
+        if index == last_user_idx and thinking_mode == "thinking":
+            prompt += thinking_start_token
+        else:
+            prompt += thinking_end_token
+
+    elif role == "tool":
+        prev_assistant_idx = index - 1
+        assistant_msg = messages[prev_assistant_idx]
+        while prev_assistant_idx >= 0 and assistant_msg.get("role") == "tool":
+            prev_assistant_idx -= 1
+            assistant_msg = messages[prev_assistant_idx]
+
+        assert (
+            index == 0
+            or prev_assistant_idx >= 0
+            and assistant_msg.get("role") == "assistant"
+        ), f"Invalid messages at {index}:\n{assistant_msg}"
+
+        tool_call_order = index - prev_assistant_idx
+        assistant_tool_calls = assistant_msg.get("tool_calls")
+        assert assistant_tool_calls and len(assistant_tool_calls) >= tool_call_order, (
+            "No tool calls but found tool output"
+        )
+
+        if tool_call_order == 1:
+            prompt += "\n\n<function_results>"
+
+        prompt += tool_output_template.format(content=content)
+
+        if tool_call_order == len(assistant_tool_calls):
+            prompt += "\n</function_results>"
+
+            if index >= last_user_idx and thinking_mode == "thinking":
+                prompt += "\n\n" + thinking_start_token
+            else:
+                prompt += "\n\n" + thinking_end_token
+
+    elif role == "assistant":
+        prev_assistant_idx = index
+        thinking_part = ""
+
+        tool_calls_content = ""
+        if tool_calls:
+            tool_calls = [
+                tool_call_template.format(
+                    dsml_token=dsml_token,
+                    name=tool_call.get("name"),
+                    arguments=encode_arguments_to_dsml(tool_call),
+                )
+                for tool_call in tool_calls
+            ]
+            tool_calls_content += "\n\n" + tool_calls_template.format(
+                dsml_token=dsml_token, tool_calls="\n".join(tool_calls)
+            )
+
+        summary_content = content or ""
+
+        if thinking_mode == "thinking" and index > last_user_idx:
+            assert reasoning_content or tool_calls, (
+                f"ThinkingMode: {thinking_mode}, invalid message without reasoning_content/tool_calls `{msg}` after last user message"
+            )
+            thinking_part = (
+                thinking_template.format(reasoning_content=reasoning_content or "")
+                + thinking_end_token
+            )
+
+        if not tool_calls and is_prefix:
+            prompt += summary_content
+        else:
+            prompt += assistant_msg_template.format(
+                reasoning=thinking_part,
+                content=summary_content,
+                tool_calls=tool_calls_content,
+            )
+    else:
+        raise NotImplementedError(f"Unknown role: {role}")
+
+    return prompt
+
+
+def drop_thinking_messages(
+    messages: list[dict[str, Any]], last_user_idx: int | None = None
+) -> list[dict[str, Any]]:
+    messages_wo_thinking: list[dict[str, Any]] = []
+    last_user_idx = (
+        find_last_user_index(messages) if last_user_idx is None else last_user_idx
+    )
+    for idx, msg in enumerate(messages):
+        role = msg.get("role")
+        if role in ["user", "system", "tool"] or idx >= last_user_idx:
+            messages_wo_thinking.append(msg)
+            continue
+
+        elif role == "assistant":
+            msg_wo_thinking = copy.copy(msg)
+            msg_wo_thinking.pop("reasoning_content", None)
+            msg_wo_thinking.pop("reasoning", None)
+            messages_wo_thinking.append(msg_wo_thinking)
+
+    return messages_wo_thinking
+
+
+def encode_messages(
+    messages: list[dict[str, Any]],
+    thinking_mode: str,
+    context: list[dict[str, Any]] | None = None,
+    drop_thinking: bool = True,
+    add_default_bos_token: bool = True,
+) -> str:
+    context = context if context else []
+    full_messages = context + messages
+
+    prompt = bos_token if add_default_bos_token and len(context) == 0 else ""
+
+    if thinking_mode == "thinking" and drop_thinking:
+        full_messages = drop_thinking_messages(full_messages)
+
+    for idx in range(len(messages)):
+        prompt += render_message(
+            idx + len(context), full_messages, thinking_mode=thinking_mode
+        )
+
+    return prompt
+
+
+def _read_until_stop(
+    index: int, text: str, stop: list[str]
+) -> tuple[int, str, None | str]:
+    min_pos = len(text)
+    matched_stop = None
+
+    for s in stop:
+        pos = text.find(s, index)
+        if pos != -1 and pos < min_pos:
+            min_pos = pos
+            matched_stop = s
+
+    if matched_stop:
+        content = text[index:min_pos]
+        return min_pos + len(matched_stop), content, matched_stop
+    else:
+        content = text[index:]
+        return len(text), content, None
+
+
+def parse_tool_calls(index: int, text: str):
+    tool_calls: list[dict[str, Any]] = []
+    stop_token = None
+    tool_calls_end_token = f"</{dsml_token}function_calls>"
+
+    while index < len(text):
+        index, _, stop_token = _read_until_stop(
+            index, text, [f"<{dsml_token}invoke", tool_calls_end_token]
+        )
+        assert _ == ">\n", "Tool call format error"
+
+        if stop_token == tool_calls_end_token:
+            break
+
+        assert stop_token is not None, "Missing special token"
+
+        index, tool_name_content, stop_token = _read_until_stop(
+            index, text, [f"<{dsml_token}parameter", f"</{dsml_token}invoke"]
+        )
+
+        p_tool_name = re.findall(
+            r'^\s*name="(.*?)">\n$', tool_name_content, flags=re.DOTALL
+        )
+        assert len(p_tool_name) == 1, "Tool name format error"
+        tool_name = p_tool_name[0]
+
+        tool_args: dict[str, tuple[str, str]] = {}
+        while stop_token == f"<{dsml_token}parameter":
+            index, param_content, stop_token = _read_until_stop(
+                index, text, [f"/{dsml_token}parameter"]
+            )
+
+            param_kv = re.findall(
+                r'^ name="(.*?)" string="(true|false)">(.*?)<$',
+                param_content,
+                flags=re.DOTALL,
+            )
+            assert len(param_kv) == 1, "Parameter format error"
+            param_name, string, param_value = param_kv[0]
+
+            assert param_name not in tool_args, "Duplicate parameter name"
+            tool_args[param_name] = (param_value, string)
+
+            index, content, stop_token = _read_until_stop(
+                index, text, [f"<{dsml_token}parameter", f"</{dsml_token}invoke"]
+            )
+            assert content == ">\n", "Parameter format error"
+
+        tool_call = decode_dsml_to_arguments(tool_name=tool_name, tool_args=tool_args)
+        tool_calls.append(tool_call)
+
+    return index, stop_token, tool_calls
+
+
+# NOTE: This function is designed to parse only correctly
+# formatted string and will not attempt to correct malformed output
+# that may be generated by the model.
+def parse_message_from_completion_text(text: str, thinking_mode: str):
+    summary_content, reasoning_content, tool_calls = "", "", []
+    index, stop_token = 0, None
+    tool_calls_start_token = f"\n\n<{dsml_token}function_calls"
+
+    is_thinking, is_tool_calling = thinking_mode == "thinking", False
+
+    if is_thinking:
+        index, content_delta, stop_token = _read_until_stop(
+            index, text, [thinking_end_token, tool_calls_start_token]
+        )
+        reasoning_content = content_delta
+        assert stop_token == thinking_end_token, "Invalid thinking format"
+
+    index, content_delta, stop_token = _read_until_stop(
+        index, text, [eos_token, tool_calls_start_token]
+    )
+    summary_content = content_delta
+    if stop_token == tool_calls_start_token:
+        is_tool_calling = True
+    else:
+        assert stop_token == eos_token, "Invalid summary format"
+
+    if is_tool_calling:
+        index, stop_token, tool_calls = parse_tool_calls(index, text)
+
+        index, tool_ends_text, stop_token = _read_until_stop(index, text, [eos_token])
+        assert not tool_ends_text, "Unexpected content after tool calls"
+
+    assert len(text) == index and stop_token in [eos_token, None], (
+        "Unexpected content at end"
+    )
+
+    for sp_token in [
+        bos_token,
+        eos_token,
+        thinking_start_token,
+        thinking_end_token,
+        dsml_token,
+    ]:
+        assert sp_token not in summary_content and sp_token not in reasoning_content, (
+            "Unexpected special token in content"
+        )
+
+    return {
+        "role": "assistant",
+        "content": summary_content,
+        "reasoning_content": reasoning_content,
+        "reasoning": reasoning_content,
+        "tool_calls": tool_calls_to_openai_format(tool_calls),
+    }

--- a/vllm/tokenizers/deepseekv32.py
+++ b/vllm/tokenizers/deepseekv32.py
@@ -1,0 +1,163 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from pathlib import Path
+from typing import Any, overload
+
+from transformers import BatchEncoding
+
+from .deepseek_v32_encoding import encode_messages
+from .hf import HfTokenizer, TokenizerLike
+from .registry import TokenizerRegistry
+
+
+@TokenizerRegistry.register("deepseek_v32")
+class DeepseekV32Tokenizer(HfTokenizer):
+    def __init__(self, tokenizer: TokenizerLike):
+        self.tokenizer = tokenizer
+        self.name_or_path = (
+            tokenizer.name_or_path if hasattr(tokenizer, "name_or_path") else ""
+        )
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        path_or_repo_id: str | Path,
+        *args,
+        trust_remote_code: bool = False,
+        revision: str | None = None,
+        download_dir: str | None = None,
+        **kwargs,
+    ) -> "TokenizerLike":
+        tokenizer = super().from_pretrained(
+            path_or_repo_id,
+            *args,
+            trust_remote_code=trust_remote_code,
+            revision=revision,
+            download_dir=download_dir,
+            **kwargs,
+        )
+        return DeepseekV32Tokenizer(tokenizer)
+
+    def apply_chat_template(self, messages, tools=None, **kwargs):
+        thinking = kwargs.get("thinking", False)
+        enable_thinking = kwargs.get("enable_thinking", False)
+        thinking = thinking or enable_thinking
+        thinking_mode = "thinking"
+        if not thinking:
+            thinking_mode = "chat"
+        conversation = kwargs.get("conversation", messages)
+        messages = conversation.copy()
+        drop_thinking = True
+        if tools is not None and len(tools) > 0:
+            messages.insert(0, {"role": "system"})
+            messages[0]["tools"] = tools
+            drop_thinking = False
+        encode_config = dict(thinking_mode=thinking_mode, drop_thinking=drop_thinking)
+        prompt_str = encode_messages(messages, **encode_config)  # type: ignore
+        return prompt_str
+
+    @property
+    def all_special_tokens(self) -> list[str]:
+        return self.tokenizer.all_special_tokens
+
+    @property
+    def all_special_ids(self) -> list[int]:
+        return self.tokenizer.all_special_ids
+
+    @property
+    def bos_token_id(self) -> int:
+        return self.tokenizer.bos_token_id
+
+    @property
+    def eos_token_id(self) -> int:
+        return self.tokenizer.eos_token_id
+
+    @property
+    def pad_token_id(self) -> int:
+        return self.tokenizer.pad_token_id
+
+    @property
+    def is_fast(self) -> bool:
+        return self.tokenizer.is_fast
+
+    @property
+    def vocab_size(self) -> int:
+        return self.tokenizer.vocab_size
+
+    @property
+    def max_token_id(self) -> int:
+        return self.tokenizer.max_token_id
+
+    @property
+    def truncation_side(self) -> str:
+        return self.tokenizer.truncation_side
+
+    def __hash__(self) -> int:
+        return hash(id(self))
+
+    def __len__(self) -> int:
+        # </think> is an added token in DeepseekV32 tokenizer
+        return self.vocab_size + len(self.get_added_vocab())
+
+    def __call__(
+        self,
+        text: str | list[str],
+        text_pair: str | None = None,
+        add_special_tokens: bool = True,
+        truncation: bool = False,
+        max_length: int | None = None,
+    ) -> "BatchEncoding":
+        return self.tokenizer(
+            text,
+            text_pair=text_pair,
+            add_special_tokens=add_special_tokens,
+            truncation=truncation,
+            max_length=max_length,
+        )
+
+    def get_vocab(self) -> dict[str, int]:
+        return self.tokenizer.get_vocab()
+
+    def get_added_vocab(self) -> dict[str, int]:
+        return self.tokenizer.get_added_vocab()
+
+    def encode(
+        self,
+        text: str,
+        truncation: bool | None = None,
+        max_length: int | None = None,
+        add_special_tokens: bool = True,
+    ) -> list[int]:
+        return self.tokenizer.encode(
+            text,
+            truncation=truncation,
+            max_length=max_length,
+            add_special_tokens=add_special_tokens,
+        )
+
+    @overload
+    def convert_tokens_to_ids(self, tokens: str) -> int: ...
+
+    @overload
+    def convert_tokens_to_ids(self, tokens: list[str]) -> list[int]: ...
+
+    def convert_tokens_to_ids(self, tokens: str | list[str]) -> int | list[int]:
+        return self.tokenizer.convert_tokens_to_ids(tokens)
+
+    def convert_tokens_to_string(self, tokens: list[str]) -> str:
+        return self.tokenizer.convert_tokens_to_string(tokens)
+
+    def decode(self, ids: list[int] | int, skip_special_tokens: bool = False) -> str:
+        return self.tokenizer.decode(ids, skip_special_tokens=skip_special_tokens)
+
+    def convert_ids_to_tokens(
+        self,
+        ids: list[int],
+        skip_special_tokens: bool = False,
+    ) -> list[str]:
+        return self.tokenizer.convert_ids_to_tokens(
+            ids, skip_special_tokens=skip_special_tokens
+        )
+
+   

--- a/vllm/tokenizers/mistral.py
+++ b/vllm/tokenizers/mistral.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, cast, overload
 
 from vllm.logger import init_logger
 
@@ -445,6 +445,15 @@ class MistralTokenizer(TokenizerLike):
         return self.transformers_tokenizer.batch_decode(
             ids, skip_special_tokens=skip_special_tokens
         )
+
+    @overload
+    def convert_tokens_to_ids(self, tokens: str) -> int: ...
+
+    @overload
+    def convert_tokens_to_ids(self, tokens: list[str]) -> list[int]: ...
+
+    def convert_tokens_to_ids(self, tokens: str | list[str]) -> int | list[int]:
+        return self.transformers_tokenizer.convert_tokens_to_ids(tokens)    
 
     def convert_tokens_to_string(self, tokens: list[str]) -> str:
         from mistral_common.tokens.tokenizers.base import (

--- a/vllm/tokenizers/protocol.py
+++ b/vllm/tokenizers/protocol.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol, overload
 
 if TYPE_CHECKING:
     from transformers import BatchEncoding
@@ -95,6 +95,15 @@ class TokenizerLike(Protocol):
         tools: list[dict[str, Any]] | None = None,
         **kwargs,
     ) -> list[int]:
+        raise NotImplementedError
+
+    @overload
+    def convert_tokens_to_ids(self, tokens: str) -> int: ...
+
+    @overload
+    def convert_tokens_to_ids(self, tokens: list[str]) -> list[int]: ...
+
+    def convert_tokens_to_ids(self, tokens: str | list[str]) -> int | list[int]:
         raise NotImplementedError
 
     def convert_tokens_to_string(self, tokens: list[str]) -> str:

--- a/vllm/v1/attention/backends/mla/common.py
+++ b/vllm/v1/attention/backends/mla/common.py
@@ -256,8 +256,10 @@ try:
     is_vllm_fa = True
 except ImportError:
     # For rocm use upstream flash attention
-    if current_platform.is_rocm():
+    if current_platform.is_rocm() and not envs.VLLM_ROCM_USE_LEGACY_TRITON_FA:
         from flash_attn import flash_attn_varlen_func
+    if envs.VLLM_ROCM_USE_LEGACY_TRITON_FA:
+        from vllm.attention.ops.triton_flash_attention import triton_attention as flash_attn_varlen_func
     is_vllm_fa = False
 
 try:
@@ -1341,13 +1343,30 @@ class MLACommonImpl(MLACommonBaseImpl[M], Generic[M]):
         if vllm_is_batch_invariant():
             kwargs["num_splits"] = 1
 
-        attn_out = self.flash_attn_varlen_func(
-            q=q,
-            k=k,
-            v=maybe_padded_v,
-            softmax_scale=softmax_scale,
-            **kwargs,
-        )
+        if envs.VLLM_ROCM_USE_LEGACY_TRITON_FA:
+            # The output of triton_attention is a tuple of
+            # [output_tensor, encoded_softmax] where encoded_softmax is always None
+            attn_out, _ = self.flash_attn_varlen_func(
+                q,
+                k,
+                maybe_padded_v,
+                None,  # output
+                kwargs["cu_seqlens_q"],
+                kwargs["cu_seqlens_k"],
+                kwargs["max_seqlen_q"],
+                kwargs["max_seqlen_k"],
+                kwargs["causal"],
+                softmax_scale,
+                None,  # bias
+            )
+        else:
+            attn_out = self.flash_attn_varlen_func(
+                q=q,
+                k=k,
+                v=maybe_padded_v,
+                softmax_scale=softmax_scale,
+                **kwargs,
+            )
 
         # Unpack the output if there is multiple results
         lse = None
@@ -1357,8 +1376,16 @@ class MLACommonImpl(MLACommonBaseImpl[M], Generic[M]):
         # Remain consistent with old `flash_attn_varlen_func` where there
         # is only one output tensor if `return_softmax_lse` is False.
         if return_softmax_lse:
-            return attn_out, lse
-        return attn_out
+            # LSE from triton kernel does not work, producing garbage outputs (see PR-14316 https://github.com/vllm-project/vllm/pull/14316).
+            # And the PR-14316 which introduces fallback to flash-attn does not work for gfx906
+            # as flash-attn with CK (composable kernel) backend is not working with gfx906 (even if the build is OK) for now. 
+            # And flash-attn with triton backend does not work neither as said previously. 
+            # TODO: MLA implementation needs to be fixed and updated when there's a working LSE for gfx906
+            # In the meantime, --no-enable-prefix-caching and --no-enable-chunked-prefill are mandatory when using gfx906 to run MLA (without sparse)
+            # These settings will always set has_context to false and so avoid running the computation of prefill context and the merge_attn_states (where LSE is required)
+            return attn_out, lse # LSE shape expected by triton_merge_attn_states is: [NUM_HEADS, NUM_TOKENS]
+        
+        return attn_out  
 
     def _run_prefill_new_tokens_fa(
         self, prefill: MLACommonPrefillMetadata, q, k, v, return_softmax_lse

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -26,7 +26,7 @@ logger = init_logger(__name__)
 class DeepseekV32IndexerBackend(AttentionBackend):
     @staticmethod
     def get_supported_kernel_block_sizes() -> list[int | MultipleOf]:
-        return [1 if current_platform.is_rocm() else 64]
+        return [1, 64]
 
     @classmethod
     def get_supported_head_sizes(cls) -> list[int]:

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla_sparse.py
@@ -66,7 +66,8 @@ class ROCMAiterMLASparseBackend(AttentionBackend):
 
     @classmethod
     def get_supported_dtypes(cls) -> list[torch.dtype]:
-        return [torch.bfloat16]
+        # --- float16 added for gfx906 support ---
+        return [torch.float16, torch.bfloat16]
 
     @classmethod
     def get_supported_head_sizes(cls) -> list[int]:
@@ -226,7 +227,7 @@ class ROCMAiterMLASparseImpl(MLACommonBaseImpl[ROCMAiterMLASparseMetadata]):
         self.topk_indices_buffer = indexer.topk_indices_buffer
         self.is_fp8bmm_enabled = rocm_aiter_ops.is_fp8bmm_enabled()
 
-    def _forward_bf16_kv(
+    def _forward_fp16_bf16_kv(
         self,
         q: torch.Tensor,
         kv_c_and_k_pe_cache: torch.Tensor,
@@ -317,7 +318,7 @@ class ROCMAiterMLASparseImpl(MLACommonBaseImpl[ROCMAiterMLASparseMetadata]):
                 scale=layer._k_scale,
             )
 
-        attn_out = self._forward_bf16_kv(
+        attn_out = self._forward_fp16_bf16_kv(
             q, kv_cache, topk_indices_global, attn_metadata
         )
 

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla_sparse.py
@@ -163,32 +163,44 @@ class ROCMAiterMLASparseMetadataBuilder(
 
 
 # Take from
-# https://github.com/deepseek-ai/FlashMLA/blob/main/tests/test_flash_mla_prefill.py#L72
+# https://github.com/deepseek-ai/FlashMLA/blob/082094b793fcc7452977d0a71a00e266a2e3061e/tests/ref.py
 def reference_mla_sparse_prefill(
-    q: torch.Tensor, kv: torch.Tensor, indices: torch.Tensor, sm_scale: float, d_v: int
+    q: torch.Tensor, 
+    kv: torch.Tensor, 
+    indices: torch.Tensor, 
+    sm_scale: float, 
+    d_v: int,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    import math
-
-    def log2sumexp2(a: torch.Tensor, dim: int) -> torch.Tensor:
-        return torch.logsumexp(a * math.log(2), dim=dim) * math.log2(math.e)
-
-    skv = kv.shape[0]
-    sq = q.shape[0]
+    """
+    Returns:
+    - o: [s_q, h_q, dv]
+    - None (lse not returned as not used in the current implementation)
+    """
+    indices = indices.clone().squeeze(1)
     topk = indices.shape[-1]
-    dqk = q.shape[-1]
-    indices = indices[:, 0, :]  # [s_q, topk]
-    invalid_indices_mask = (indices < 0) | (indices >= skv)
-    indices[invalid_indices_mask] = 0
-    qs = q  # [s_q, h_q, d_qk]
-    kvs = kv[:, 0, :][indices].view(sq, topk, dqk)  # [s_q, topk, d_qk]
+    s_kv = kv.shape[0]
+    s_q, h_q, d_qk = q.shape  # [s_q, h_q, d_qk]
+    invalid_mask = (indices < 0) | (indices >= s_kv)    # [s_q, topk]
+    indices[invalid_mask] = 0
 
-    attn_score = (qs @ kvs.transpose(1, 2)).float()  # [s_q, h_q, topk]
-    attn_score.masked_fill_(invalid_indices_mask.unsqueeze(1), float("-inf"))
-    attn_score *= sm_scale * math.log2(math.e)
-    lse = log2sumexp2(attn_score, dim=-1)  # [s_q, h_q]
-    attn_score = torch.exp2(attn_score - lse.unsqueeze(-1))  # [s_q, h_q, topk]
-    result = attn_score.to(q.dtype) @ kvs[:, :, :d_v]
-    return (result, lse)
+    q = q.float()
+    gathered_kv = kv.index_select(dim=0, index=indices.flatten()).reshape(s_q, topk, d_qk).float()   # [s_q, topk, d_qk]
+    P = (q @ gathered_kv.transpose(1, 2))   # [s_q, h_q, topk]
+    P *= sm_scale
+    P[invalid_mask.unsqueeze(1).broadcast_to(P.shape)] = float("-inf")
+
+    orig_lse = torch.logsumexp(P, dim=-1)   # [s_q, h_q]
+    #max_logits = P.max(dim=-1).values   # [s_q, h_q]
+
+    if not torch.is_inference_mode_enabled():
+        orig_lse = orig_lse.clone()
+    orig_lse[orig_lse == float("-inf")] = float("+inf")   # So that corresponding O will be 0
+    s_for_o = torch.exp(P - orig_lse.unsqueeze(-1))
+    out = s_for_o @ gathered_kv[..., :d_v]   # [s_q, h_q, dv]
+
+    #lonely_q_mask = orig_lse == float("-inf")   # [s_q, h_q]
+    #orig_lse[lonely_q_mask] = float("+inf")
+    return (out.to(kv.dtype), None)
 
 
 class ROCMAiterMLASparseImpl(MLACommonBaseImpl[ROCMAiterMLASparseMetadata]):


### PR DESCRIPTION
# Summary 

1) [ROCm] Add AMD GFX906 GPU support on Deepseek and MLA (without Sparse)
2) [ROCm] Boost AMD GFX906 performance for Deepseek (TP16-PP1, TP8-PP2, TP4-PP4)
3) [ROCm] Add AMD GFX906 GPU support on Deepseek and MLA with SPARSE (with vllm DS PRs: 27568, 30841, 31046, 31261)

# Testing 

## 1st commit: MLA without Sparse

- Model: https://huggingface.co/QuantTrio/DeepSeek-V3.2-AWQ
- Command:

```code
PYTORCH_ALLOC_CONF="expandable_segments:True" OMP_NUM_THREADS=4 TORCH_ALLOW_TF32_CUBLAS_OVERRIDE=1 VLLM_MLA_SPARSE_DISABLE_EXPERIMENTAL=1 VLLM_ROCM_USE_LEGACY_TRITON_FA=1 VLLM_ATTENTION_BACKEND="TRITON_MLA" NCCL_P2P_DISABLE=1 VLLM_MLA_DISABLE=0 VLLM_USE_TRITON_AWQ=1 VLLM_LOGGING_LEVEL=DEBUG NCCL_DEBUG=INFO vllm serve ~/llm/models/DeepSeek-V3.2-AWQ \
    --served-model-name DeepSeek-V3.2-AWQ  \
    --reasoning-parser deepseek_r1 \
    --no-enable-prefix-caching \
    --no-enable-chunked-prefill \
    --max-num-seqs 32 \
    --enable-log-requests \
    --enable-log-outputs \
    --log-error-stack \
    --tensor-parallel-size 16 --pipeline-parallel-size 1 --max-model-len 12000 --gpu-memory-utilization 0.92 \
    --chat-template ~/llm/models/DeepSeek-V3.2-AWQ/chat_template.jinja \
    --swap-space 0 2>&1 | tee log.txt
```

- Performance (peak): TG (token generation): 10.2 tok/s / PP (prompt processing): variable according to request length (600 tok > 89 tok/s ; 8k tok > 1065 tok/s etc...)

- Limitations: 
1) Answers are pretty consistent until the context length is almost filled and then can produce garbage (> 8-10k tok).
2) Bug/Anomaly: VRAM usage increases according to the context increase and goes higher to the limit set by gpu-memory-utilization (might due to wrong kv cache calculation with MLA and --no-enable-prefix-caching and  --no-enable-chunked-prefill)
3) Max context length is small due to --no-enable-chunked-prefill. But mandatory here as LSE triton kernel (used during prefill context compute and merge attention states) does not work and LSE upstream FA for gfx906 (with composable kernel, 6.3.4) does not work neither for now (producing garbage).

## 3rd commit: MLA with Sparse

- Model: https://huggingface.co/QuantTrio/DeepSeek-V3.2-AWQ
- Command: 

```code
PYTORCH_ALLOC_CONF="expandable_segments:True" OMP_NUM_THREADS=4 TORCH_ALLOW_TF32_CUBLAS_OVERRIDE=1 VLLM_ROCM_USE_LEGACY_TRITON_FA=1 VLLM_ATTENTION_BACKEND="ROCM_AITER_MLA_SPARSE" VLLM_ROCM_USE_AITER_MLA_SPARSE_FP16=1 VLLM_ROCM_USE_AITER=0 NCCL_P2P_DISABLE=1 VLLM_MLA_DISABLE=0 VLLM_USE_TRITON_AWQ=1 NCCL_DEBUG=INFO vllm serve ~/llm/models/DeepSeek-V3.2-AWQ \
    --served-model-name DeepSeek-V3.2-AWQ  \
    --tensor-parallel-size 16 --pipeline-parallel-size 1 --max-model-len 73000 --gpu-memory-utilization 0.91 \
    --chat-template ~/llm/models/DeepSeek-V3.2-AWQ/chat_template.jinja \
    --reasoning-parser deepseek_r1 \
    --block-size 64 \
    --max-num-seqs 32 \
    --max-num-batched-tokens 512 \
    --speculative-config '{"model": "~/llm/models/DeepSeek-V3.2-AWQ", "num_speculative_tokens": 1}' \
    --no-enable-prefix-caching \
    --kv-cache-dtype auto \
    --enable-log-requests \
    --enable-log-outputs \
    --log-error-stack \
    --swap-space 0 2>&1 | tee log.txt
```

- Performance: TG (token generation): 10.7 tok/s / PP (prompt processing): variable according to request length (600 tok > 93 tok/s ; 23k tok > 2518 tok/s etc... but long request implies longer pre processing, it lasts in reality 15min to handle 23k tok before decoding phase)

- Limitations: 
1) With MTP, answers are pretty consistent (10k tok filled in context), then with big prompt (23k tokens), MTP crashes during decoding. And without MTP, it's less steady, garbage is produced after ~2k tokens only. 
2) It adds max +6-7% GPU VRAM from gpu-memory-utilization value, the profiler run based on sparse_attn_indexer_fake must be fixed/improved
3) Higher max-num-batched-tokens from 512 can produce HIP out of memory 

# Side notes / future work

- This is a first non optimized attempt to make Deepseek MLA run on GFX906 hardware, so there's still a lot of room for speed, GPU memory usage and stability improvements

- [x] 1) The fused moe configs gives +~0.5 t/s in TG and if num_stages = 2, it will produce garbage with existing code, so it has been kept to num_stages = 1. With OMP_NUM_THREADS=4 and --max-num-seqs 32 (which will decrease default cuda graph piecewise size), we notice +0.5 t/s in TG

- [x] 2) I tried to replace reference_mla_sparse_prefill(...) from v1/attention/backends/mla/rocm_aiter_mla_sparse.py by unified_attention_sparse_mla  from aiter 0.1.9, it was working but with lower performance (1.8 tok/s in TG with TP 4 PP 4) as this triton kernel was not optimized and relevant for this use case. Maybe there's a little bit room to optimize this function for GFX906.

- [ ] 3)  If possible, fp16_paged_mqa_logits_torch and fp16_mqa_logits_torch should be replaced by better optimized functions (triton kernel, ...) 

- [x] 4) Steps 1 and 2 written in python/pytorch (cache population and key retrieval)  from sparse_attn_indexer should be improved with C++/hip Kernel equivalent.

- [x] 5) Add recent DS v3.2 tokenizer (already done in main branch vllm) 

- [ ] 6) Should be tested properly with lm_eval tasks wikitext and gsm8k (as it's usually done by vllm team, see: https://github.com/vllm-project/vllm/pull/26670) 

**EDIT**: notes 3) and 4) have been done in https://github.com/nlzy/vllm-gfx906/pull/62/commits/5d6cfc990b54fcd19fb7cfca987267a2ef86022b  ([ROCm] Major GFX906 optimizations for SparseMLA FP16 Ops using Triton and HIP kernels) , it gives +~30% in decode/prefill speed (TG can reach 13.8 tok/s with max-num-batched-tokens 2048). I will add in a future commit the tests files related to this major update (based on official deepseek deepgemm repo tests)

**EDIT2**: after some unit tests, it does not seem to have a lot of room for optimizations related to note 2) (TFLOPS and GB/s was still quite high at 4.89 TFLOPS/s for S_Q=512, TopK=2048, S_KV=32768, d_qk = 576  with last commit (#6) on reference_sparse_prefill. NB: FP32 max computation for mi50 is 13.25 TFLOPS/s). So this task/note can be considered as done.

**EDIT3**: Task 3 should be improved as with current implementation, fp16_mqa_logits triton  is slower than torch ref and fp16_paged_mqa_logits triton seems less stable than torch ref (at 18k+ tok context).